### PR TITLE
core/test failure fix. 

### DIFF
--- a/core/src/test/java/eu/excitementproject/eop/core/EditDistanceEDATest.java
+++ b/core/src/test/java/eu/excitementproject/eop/core/EditDistanceEDATest.java
@@ -8,23 +8,17 @@ import java.util.List;
 import java.util.ArrayList;
 import eu.excitementproject.eop.common.configuration.CommonConfig;
 import eu.excitementproject.eop.lap.LAPException;
-import eu.excitementproject.eop.lap.lappoc.OpenNLPTaggerEN;
+import eu.excitementproject.eop.lap.lappoc.ExampleLAP;
 
 public class EditDistanceEDATest {
 
 	@Test
 	public void test() {
-    	
-//        EditDistanceEDATest editDistance
-//            = new EditDistanceEDATest();
-        
-        // CasCreation is basically a broken code (since it uses file path)  
-        // I replaced the code to lap/SampleLAP  --- Gil 
-        
-        OpenNLPTaggerEN lap = null; 
+    	        
+        ExampleLAP lap = null; 
         try 
         {
-        	lap = new OpenNLPTaggerEN(); 
+        	lap = new ExampleLAP(); 
         }
         catch (LAPException e)
         {

--- a/core/src/test/java/eu/excitementproject/eop/core/component/distance/FixedWeightTokenEditDistanceTest.java
+++ b/core/src/test/java/eu/excitementproject/eop/core/component/distance/FixedWeightTokenEditDistanceTest.java
@@ -4,7 +4,7 @@ import org.apache.uima.jcas.JCas;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import eu.excitementproject.eop.lap.LAPException;
-import eu.excitementproject.eop.lap.lappoc.OpenNLPTaggerEN;
+import eu.excitementproject.eop.lap.lappoc.ExampleLAP;
 
 
 public class FixedWeightTokenEditDistanceTest {
@@ -14,16 +14,12 @@ public class FixedWeightTokenEditDistanceTest {
     	
         FixedWeightTokenEditDistance fixedEd
             = new FixedWeightTokenEditDistance();
-
-        // removed using of CasCreation - Gil 
-        //CasCreation  aCas = new CasCreation();
-        //JCas mycas = aCas.create();
         
         JCas mycas = null; 
-        OpenNLPTaggerEN lap = null; 
+        ExampleLAP lap = null; 
         try 
         {
-        	lap = new OpenNLPTaggerEN(); 
+        	lap = new ExampleLAP(); 
             mycas = lap.generateSingleTHPairCAS("The person is hired as a postdoc.", "The person must have a PhD.", "ENTAILMENT"); 
         }
         catch(LAPException e)


### PR DESCRIPTION
Changing ExampleLAP to OpenNLP tagger brough a test failure in core (distance component). revert it back to ExampleLAP.
