### PR TITLE
Changed project pom.xml to let Maven work with the Excitement repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,41 @@
   		</dependency>
   	</dependencies>
   </dependencyManagement>
+
+  <repositories>
+	<repository>
+ 		<id>central</id>
+     	<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
+     	<snapshots>
+       		<enabled>false</enabled>
+     	</snapshots>
+ 	</repository>
+   	<repository>
+   		<id>snapshots</id>
+     	<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
+      	<releases>
+       		<enabled>false</enabled>
+   		</releases>
+  	</repository>
+  </repositories>
+  
+  <pluginRepositories>
+ 	<pluginRepository>
+   	<id>central</id>
+  	<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
+   	<snapshots>
+   		<enabled>false</enabled>
+  	</snapshots>
+  </pluginRepository>
+  	<pluginRepository>
+		<id>snapshots</id>
+  		<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
+  		<releases>
+   			<enabled>false</enabled>
+  		</releases>
+   	</pluginRepository>
+  </pluginRepositories>
+
   <build>
   	<plugins>
 		<plugin>


### PR DESCRIPTION
A repository in Maven is used to hold build artifacts and dependencies of varying types.
There are  two types of repositories: local and remote. The local repository refers to a copy on your own installation that is a cache of the remote downloads,
If Maven can’t find the defined dependency libraries in your Maven local repository, it will try to download it from the default Maven central repository, which is http://repo1.maven.org/maven2/.
We have changed pom.xml to tell Maven to use our internal Excitement Maven repository instead of the default repository.
