### PR TITLE
Resolving POM problems and warnings, also JCAS warnings. 

### DIFF
--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceChain.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceChain.java
@@ -18,12 +18,12 @@ public class CoreferenceChain extends AnnotationBase {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CoreferenceChain.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceChain_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceChain_Type.java
@@ -37,11 +37,11 @@ public class CoreferenceChain_Type extends AnnotationBase_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CoreferenceChain.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceChain");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceLink.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceLink.java
@@ -18,12 +18,12 @@ public class CoreferenceLink extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CoreferenceLink.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceLink_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/coref/type/CoreferenceLink_Type.java
@@ -37,11 +37,11 @@ public class CoreferenceLink_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CoreferenceLink.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceLink");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADJ.java
@@ -17,12 +17,12 @@ public class ADJ extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ADJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADJ_Type.java
@@ -34,11 +34,11 @@ public class ADJ_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ADJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.ADJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADV.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADV.java
@@ -17,12 +17,12 @@ public class ADV extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ADV.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADV_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ADV_Type.java
@@ -34,11 +34,11 @@ public class ADV_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ADV.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.ADV");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ART.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ART.java
@@ -17,12 +17,12 @@ public class ART extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ART.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ART_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/ART_Type.java
@@ -34,11 +34,11 @@ public class ART_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ART.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.ART");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CARD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CARD.java
@@ -17,12 +17,12 @@ public class CARD extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CARD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CARD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CARD_Type.java
@@ -34,11 +34,11 @@ public class CARD_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CARD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.CARD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CONJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CONJ.java
@@ -17,12 +17,12 @@ public class CONJ extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CONJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CONJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/CONJ_Type.java
@@ -34,11 +34,11 @@ public class CONJ_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CONJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.CONJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/N.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/N.java
@@ -17,12 +17,12 @@ public class N extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(N.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NN.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NN.java
@@ -17,12 +17,12 @@ public class NN extends N {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NN.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NN_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NN_Type.java
@@ -34,11 +34,11 @@ public class NN_Type extends N_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NN.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.NN");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NP.java
@@ -17,12 +17,12 @@ public class NP extends N {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/NP_Type.java
@@ -34,11 +34,11 @@ public class NP_Type extends N_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.NP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/N_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/N_Type.java
@@ -34,11 +34,11 @@ public class N_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = N.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.N");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/O.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/O.java
@@ -17,12 +17,12 @@ public class O extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(O.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/O_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/O_Type.java
@@ -34,11 +34,11 @@ public class O_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = O.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.O");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/POS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/POS.java
@@ -18,12 +18,12 @@ public class POS extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(POS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/POS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/POS_Type.java
@@ -37,11 +37,11 @@ public class POS_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = POS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PP.java
@@ -17,12 +17,12 @@ public class PP extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PP_Type.java
@@ -34,11 +34,11 @@ public class PP_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.PP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PR.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PR.java
@@ -17,12 +17,12 @@ public class PR extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PR.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PR_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PR_Type.java
@@ -34,11 +34,11 @@ public class PR_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PR.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.PR");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PUNC.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PUNC.java
@@ -17,12 +17,12 @@ public class PUNC extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PUNC.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PUNC_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/PUNC_Type.java
@@ -34,11 +34,11 @@ public class PUNC_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PUNC.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.PUNC");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/V.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/V.java
@@ -17,12 +17,12 @@ public class V extends POS {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(V.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/V_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/V_Type.java
@@ -34,11 +34,11 @@ public class V_Type extends POS_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = V.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.V");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Animal.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Animal.java
@@ -17,12 +17,12 @@ public class Animal extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Animal.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Animal_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Animal_Type.java
@@ -34,11 +34,11 @@ public class Animal_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Animal.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Animal");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Cardinal.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Cardinal.java
@@ -17,12 +17,12 @@ public class Cardinal extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Cardinal.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Cardinal_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Cardinal_Type.java
@@ -34,11 +34,11 @@ public class Cardinal_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Cardinal.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Cardinal");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ContactInfo.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ContactInfo.java
@@ -17,12 +17,12 @@ public class ContactInfo extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ContactInfo.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ContactInfo_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ContactInfo_Type.java
@@ -34,11 +34,11 @@ public class ContactInfo_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ContactInfo.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.ContactInfo");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Date.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Date.java
@@ -17,12 +17,12 @@ public class Date extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Date.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Date_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Date_Type.java
@@ -34,11 +34,11 @@ public class Date_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Date.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Date");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Disease.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Disease.java
@@ -17,12 +17,12 @@ public class Disease extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Disease.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Disease_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Disease_Type.java
@@ -34,11 +34,11 @@ public class Disease_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Disease.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Disease");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Event.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Event.java
@@ -17,12 +17,12 @@ public class Event extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Event.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Event_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Event_Type.java
@@ -34,11 +34,11 @@ public class Event_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Event.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Event");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Fac.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Fac.java
@@ -17,12 +17,12 @@ public class Fac extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Fac.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/FacDesc.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/FacDesc.java
@@ -17,12 +17,12 @@ public class FacDesc extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(FacDesc.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/FacDesc_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/FacDesc_Type.java
@@ -34,11 +34,11 @@ public class FacDesc_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = FacDesc.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.FacDesc");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Fac_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Fac_Type.java
@@ -34,11 +34,11 @@ public class Fac_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Fac.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Fac");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Game.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Game.java
@@ -17,12 +17,12 @@ public class Game extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Game.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Game_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Game_Type.java
@@ -34,11 +34,11 @@ public class Game_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Game.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Game");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Gpe.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Gpe.java
@@ -17,12 +17,12 @@ public class Gpe extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Gpe.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/GpeDesc.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/GpeDesc.java
@@ -17,12 +17,12 @@ public class GpeDesc extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(GpeDesc.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/GpeDesc_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/GpeDesc_Type.java
@@ -34,11 +34,11 @@ public class GpeDesc_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = GpeDesc.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.GpeDesc");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Gpe_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Gpe_Type.java
@@ -34,11 +34,11 @@ public class Gpe_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Gpe.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Gpe");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Language.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Language.java
@@ -17,12 +17,12 @@ public class Language extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Language.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Language_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Language_Type.java
@@ -34,11 +34,11 @@ public class Language_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Language.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Language");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Law.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Law.java
@@ -17,12 +17,12 @@ public class Law extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Law.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Law_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Law_Type.java
@@ -34,11 +34,11 @@ public class Law_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Law.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Law");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Location.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Location.java
@@ -17,12 +17,12 @@ public class Location extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Location.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Location_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Location_Type.java
@@ -34,11 +34,11 @@ public class Location_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Location.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Location");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Money.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Money.java
@@ -17,12 +17,12 @@ public class Money extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Money.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Money_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Money_Type.java
@@ -34,11 +34,11 @@ public class Money_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Money.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Money");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/NamedEntity.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/NamedEntity.java
@@ -18,12 +18,12 @@ public class NamedEntity extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NamedEntity.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/NamedEntity_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/NamedEntity_Type.java
@@ -37,11 +37,11 @@ public class NamedEntity_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NamedEntity.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Nationality.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Nationality.java
@@ -17,12 +17,12 @@ public class Nationality extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Nationality.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Nationality_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Nationality_Type.java
@@ -34,11 +34,11 @@ public class Nationality_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Nationality.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Nationality");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Norp.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Norp.java
@@ -17,12 +17,12 @@ public class Norp extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Norp.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Norp_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Norp_Type.java
@@ -34,11 +34,11 @@ public class Norp_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Norp.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Norp");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Ordinal.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Ordinal.java
@@ -17,12 +17,12 @@ public class Ordinal extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Ordinal.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Ordinal_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Ordinal_Type.java
@@ -34,11 +34,11 @@ public class Ordinal_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Ordinal.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Ordinal");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/OrgDesc.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/OrgDesc.java
@@ -17,12 +17,12 @@ public class OrgDesc extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(OrgDesc.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/OrgDesc_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/OrgDesc_Type.java
@@ -34,11 +34,11 @@ public class OrgDesc_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = OrgDesc.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.OrgDesc");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Organization.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Organization.java
@@ -17,12 +17,12 @@ public class Organization extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Organization.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Organization_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Organization_Type.java
@@ -34,11 +34,11 @@ public class Organization_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Organization.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Organization");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/PerDesc.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/PerDesc.java
@@ -17,12 +17,12 @@ public class PerDesc extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PerDesc.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/PerDesc_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/PerDesc_Type.java
@@ -34,11 +34,11 @@ public class PerDesc_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PerDesc.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.PerDesc");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Percent.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Percent.java
@@ -17,12 +17,12 @@ public class Percent extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Percent.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Percent_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Percent_Type.java
@@ -34,11 +34,11 @@ public class Percent_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Percent.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Percent");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Person.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Person.java
@@ -17,12 +17,12 @@ public class Person extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Person.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Person_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Person_Type.java
@@ -34,11 +34,11 @@ public class Person_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Person.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Person");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Plant.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Plant.java
@@ -17,12 +17,12 @@ public class Plant extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Plant.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Plant_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Plant_Type.java
@@ -34,11 +34,11 @@ public class Plant_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Plant.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Plant");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Product.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Product.java
@@ -17,12 +17,12 @@ public class Product extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Product.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ProductDesc.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ProductDesc.java
@@ -17,12 +17,12 @@ public class ProductDesc extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ProductDesc.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ProductDesc_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/ProductDesc_Type.java
@@ -34,11 +34,11 @@ public class ProductDesc_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ProductDesc.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.ProductDesc");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Product_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Product_Type.java
@@ -34,11 +34,11 @@ public class Product_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Product.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Product");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Quantity.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Quantity.java
@@ -17,12 +17,12 @@ public class Quantity extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Quantity.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Quantity_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Quantity_Type.java
@@ -34,11 +34,11 @@ public class Quantity_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Quantity.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Quantity");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Substance.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Substance.java
@@ -17,12 +17,12 @@ public class Substance extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Substance.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Substance_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Substance_Type.java
@@ -34,11 +34,11 @@ public class Substance_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Substance.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Substance");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Time.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Time.java
@@ -17,12 +17,12 @@ public class Time extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Time.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Time_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/Time_Type.java
@@ -34,11 +34,11 @@ public class Time_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Time.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.Time");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/WorkOfArt.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/WorkOfArt.java
@@ -17,12 +17,12 @@ public class WorkOfArt extends NamedEntity {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WorkOfArt.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/WorkOfArt_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/ner/type/WorkOfArt_Type.java
@@ -34,11 +34,11 @@ public class WorkOfArt_Type extends NamedEntity_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WorkOfArt.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.ner.type.WorkOfArt");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Compound.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Compound.java
@@ -19,12 +19,12 @@ public class Compound extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Compound.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Compound_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Compound_Type.java
@@ -37,11 +37,11 @@ public class Compound_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Compound.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Compound");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Document.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Document.java
@@ -18,12 +18,12 @@ public class Document extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Document.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Document_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Document_Type.java
@@ -35,11 +35,11 @@ public class Document_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Document.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Document");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Heading.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Heading.java
@@ -18,12 +18,12 @@ public class Heading extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Heading.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Heading_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Heading_Type.java
@@ -35,11 +35,11 @@ public class Heading_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Heading.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Heading");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Lemma.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Lemma.java
@@ -18,12 +18,12 @@ public class Lemma extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Lemma.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Lemma_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Lemma_Type.java
@@ -37,11 +37,11 @@ public class Lemma_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Lemma.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/NGram.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/NGram.java
@@ -18,12 +18,12 @@ public class NGram extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NGram.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/NGram_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/NGram_Type.java
@@ -37,11 +37,11 @@ public class NGram_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NGram.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.NGram");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Paragraph.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Paragraph.java
@@ -18,12 +18,12 @@ public class Paragraph extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Paragraph.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Paragraph_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Paragraph_Type.java
@@ -35,11 +35,11 @@ public class Paragraph_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Paragraph.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Sentence.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Sentence.java
@@ -18,12 +18,12 @@ public class Sentence extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Sentence.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Sentence_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Sentence_Type.java
@@ -35,11 +35,11 @@ public class Sentence_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Sentence.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Split.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Split.java
@@ -19,12 +19,12 @@ public class Split extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Split.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Split_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Split_Type.java
@@ -37,11 +37,11 @@ public class Split_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Split.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Split");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Stem.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Stem.java
@@ -18,12 +18,12 @@ public class Stem extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Stem.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Stem_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Stem_Type.java
@@ -37,11 +37,11 @@ public class Stem_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Stem.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Stem");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/StopWord.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/StopWord.java
@@ -18,12 +18,12 @@ public class StopWord extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(StopWord.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/StopWord_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/StopWord_Type.java
@@ -35,11 +35,11 @@ public class StopWord_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = StopWord.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.StopWord");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Token.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Token.java
@@ -19,12 +19,12 @@ public class Token extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Token.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Token_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/Token_Type.java
@@ -37,11 +37,11 @@ public class Token_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Token.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADJP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADJP.java
@@ -17,12 +17,12 @@ public class ADJP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ADJP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADJP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADJP_Type.java
@@ -34,11 +34,11 @@ public class ADJP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ADJP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.ADJP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADVP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADVP.java
@@ -17,12 +17,12 @@ public class ADVP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ADVP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADVP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ADVP_Type.java
@@ -34,11 +34,11 @@ public class ADVP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ADVP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.ADVP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CC.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CC.java
@@ -17,12 +17,12 @@ public class CC extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CC.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CC_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CC_Type.java
@@ -34,11 +34,11 @@ public class CC_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CC.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.CC");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CD.java
@@ -17,12 +17,12 @@ public class CD extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CD_Type.java
@@ -34,11 +34,11 @@ public class CD_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.CD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CONJP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CONJP.java
@@ -17,12 +17,12 @@ public class CONJP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CONJP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CONJP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/CONJP_Type.java
@@ -34,11 +34,11 @@ public class CONJP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CONJP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.CONJP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/Constituent.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/Constituent.java
@@ -19,12 +19,12 @@ public class Constituent extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Constituent.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/Constituent_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/Constituent_Type.java
@@ -37,11 +37,11 @@ public class Constituent_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Constituent.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.Constituent");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/DT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/DT.java
@@ -17,12 +17,12 @@ public class DT extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(DT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/DT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/DT_Type.java
@@ -34,11 +34,11 @@ public class DT_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = DT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.DT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/EX.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/EX.java
@@ -17,12 +17,12 @@ public class EX extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(EX.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/EX_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/EX_Type.java
@@ -34,11 +34,11 @@ public class EX_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = EX.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.EX");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FRAG.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FRAG.java
@@ -17,12 +17,12 @@ public class FRAG extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(FRAG.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FRAG_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FRAG_Type.java
@@ -34,11 +34,11 @@ public class FRAG_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = FRAG.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.FRAG");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FW.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FW.java
@@ -17,12 +17,12 @@ public class FW extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(FW.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FW_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/FW_Type.java
@@ -34,11 +34,11 @@ public class FW_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = FW.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.FW");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/IN.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/IN.java
@@ -17,12 +17,12 @@ public class IN extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(IN.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/INTJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/INTJ.java
@@ -17,12 +17,12 @@ public class INTJ extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(INTJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/INTJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/INTJ_Type.java
@@ -34,11 +34,11 @@ public class INTJ_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = INTJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.INTJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/IN_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/IN_Type.java
@@ -34,11 +34,11 @@ public class IN_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = IN.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.IN");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJ.java
@@ -17,12 +17,12 @@ public class JJ extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(JJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJR.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJR.java
@@ -17,12 +17,12 @@ public class JJR extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(JJR.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJR_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJR_Type.java
@@ -34,11 +34,11 @@ public class JJR_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JJR.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.JJR");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJS.java
@@ -17,12 +17,12 @@ public class JJS extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(JJS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJS_Type.java
@@ -34,11 +34,11 @@ public class JJS_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JJS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.JJS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/JJ_Type.java
@@ -34,11 +34,11 @@ public class JJ_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.JJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LS.java
@@ -17,12 +17,12 @@ public class LS extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(LS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LST.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LST.java
@@ -17,12 +17,12 @@ public class LST extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(LST.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LST_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LST_Type.java
@@ -34,11 +34,11 @@ public class LST_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = LST.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.LST");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/LS_Type.java
@@ -34,11 +34,11 @@ public class LS_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = LS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.LS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/MD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/MD.java
@@ -17,12 +17,12 @@ public class MD extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(MD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/MD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/MD_Type.java
@@ -34,11 +34,11 @@ public class MD_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = MD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.MD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NAC.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NAC.java
@@ -17,12 +17,12 @@ public class NAC extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NAC.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NAC_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NAC_Type.java
@@ -34,11 +34,11 @@ public class NAC_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NAC.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.NAC");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NN.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NN.java
@@ -17,12 +17,12 @@ public class NN extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NN.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNP.java
@@ -17,12 +17,12 @@ public class NNP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NNP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNPS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNPS.java
@@ -17,12 +17,12 @@ public class NNPS extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NNPS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNPS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNPS_Type.java
@@ -34,11 +34,11 @@ public class NNPS_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NNPS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.NNPS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNP_Type.java
@@ -34,11 +34,11 @@ public class NNP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NNP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.NNP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNS.java
@@ -17,12 +17,12 @@ public class NNS extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NNS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NNS_Type.java
@@ -34,11 +34,11 @@ public class NNS_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NNS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.NNS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NN_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NN_Type.java
@@ -34,11 +34,11 @@ public class NN_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NN.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.NN");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NP.java
@@ -17,12 +17,12 @@ public class NP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NP_Type.java
@@ -34,11 +34,11 @@ public class NP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.NP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NX.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NX.java
@@ -17,12 +17,12 @@ public class NX extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NX.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NX_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/NX_Type.java
@@ -34,11 +34,11 @@ public class NX_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NX.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.NX");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PDT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PDT.java
@@ -17,12 +17,12 @@ public class PDT extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PDT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PDT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PDT_Type.java
@@ -34,11 +34,11 @@ public class PDT_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PDT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.PDT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/POS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/POS.java
@@ -17,12 +17,12 @@ public class POS extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(POS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/POS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/POS_Type.java
@@ -34,11 +34,11 @@ public class POS_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = POS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.POS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PP.java
@@ -17,12 +17,12 @@ public class PP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PP_Type.java
@@ -34,11 +34,11 @@ public class PP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.PP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRN0.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRN0.java
@@ -17,12 +17,12 @@ public class PRN0 extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PRN0.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRN0_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRN0_Type.java
@@ -34,11 +34,11 @@ public class PRN0_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PRN0.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.PRN0");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRP.java
@@ -17,12 +17,12 @@ public class PRP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PRP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRPP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRPP.java
@@ -17,12 +17,12 @@ public class PRPP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PRPP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRPP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRPP_Type.java
@@ -34,11 +34,11 @@ public class PRPP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PRPP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.PRPP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRP_Type.java
@@ -34,11 +34,11 @@ public class PRP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PRP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.PRP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRT.java
@@ -17,12 +17,12 @@ public class PRT extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PRT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PRT_Type.java
@@ -34,11 +34,11 @@ public class PRT_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PRT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.PRT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PUNC.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PUNC.java
@@ -17,12 +17,12 @@ public class PUNC extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PUNC.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PUNC_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/PUNC_Type.java
@@ -34,11 +34,11 @@ public class PUNC_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PUNC.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.PUNC");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/QP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/QP.java
@@ -17,12 +17,12 @@ public class QP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(QP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/QP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/QP_Type.java
@@ -34,11 +34,11 @@ public class QP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = QP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.QP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RB.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RB.java
@@ -17,12 +17,12 @@ public class RB extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(RB.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBR.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBR.java
@@ -17,12 +17,12 @@ public class RBR extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(RBR.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBR_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBR_Type.java
@@ -34,11 +34,11 @@ public class RBR_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = RBR.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.RBR");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBS.java
@@ -17,12 +17,12 @@ public class RBS extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(RBS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RBS_Type.java
@@ -34,11 +34,11 @@ public class RBS_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = RBS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.RBS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RB_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RB_Type.java
@@ -34,11 +34,11 @@ public class RB_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = RB.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.RB");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ROOT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ROOT.java
@@ -17,12 +17,12 @@ public class ROOT extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ROOT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ROOT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/ROOT_Type.java
@@ -34,11 +34,11 @@ public class ROOT_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ROOT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.ROOT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RP.java
@@ -17,12 +17,12 @@ public class RP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(RP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RP_Type.java
@@ -34,11 +34,11 @@ public class RP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = RP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.RP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RRC.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RRC.java
@@ -17,12 +17,12 @@ public class RRC extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(RRC.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RRC_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/RRC_Type.java
@@ -34,11 +34,11 @@ public class RRC_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = RRC.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.RRC");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/S.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/S.java
@@ -17,12 +17,12 @@ public class S extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(S.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBAR.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBAR.java
@@ -17,12 +17,12 @@ public class SBAR extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(SBAR.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBARQ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBARQ.java
@@ -17,12 +17,12 @@ public class SBARQ extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(SBARQ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBARQ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBARQ_Type.java
@@ -34,11 +34,11 @@ public class SBARQ_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = SBARQ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.SBARQ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBAR_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SBAR_Type.java
@@ -34,11 +34,11 @@ public class SBAR_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = SBAR.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.SBAR");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SINV.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SINV.java
@@ -17,12 +17,12 @@ public class SINV extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(SINV.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SINV_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SINV_Type.java
@@ -34,11 +34,11 @@ public class SINV_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = SINV.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.SINV");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SQ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SQ.java
@@ -17,12 +17,12 @@ public class SQ extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(SQ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SQ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SQ_Type.java
@@ -34,11 +34,11 @@ public class SQ_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = SQ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.SQ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SYM.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SYM.java
@@ -17,12 +17,12 @@ public class SYM extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(SYM.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SYM_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/SYM_Type.java
@@ -34,11 +34,11 @@ public class SYM_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = SYM.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.SYM");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/S_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/S_Type.java
@@ -34,11 +34,11 @@ public class S_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = S.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.S");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/TO.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/TO.java
@@ -17,12 +17,12 @@ public class TO extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(TO.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/TO_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/TO_Type.java
@@ -34,11 +34,11 @@ public class TO_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = TO.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.TO");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UCP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UCP.java
@@ -17,12 +17,12 @@ public class UCP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(UCP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UCP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UCP_Type.java
@@ -34,11 +34,11 @@ public class UCP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = UCP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.UCP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UH.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UH.java
@@ -17,12 +17,12 @@ public class UH extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(UH.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UH_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/UH_Type.java
@@ -34,11 +34,11 @@ public class UH_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = UH.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.UH");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VB.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VB.java
@@ -17,12 +17,12 @@ public class VB extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(VB.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBD.java
@@ -17,12 +17,12 @@ public class VBD extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(VBD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBD_Type.java
@@ -34,11 +34,11 @@ public class VBD_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = VBD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.VBD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBG.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBG.java
@@ -17,12 +17,12 @@ public class VBG extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(VBG.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBG_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBG_Type.java
@@ -34,11 +34,11 @@ public class VBG_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = VBG.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.VBG");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBN.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBN.java
@@ -17,12 +17,12 @@ public class VBN extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(VBN.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBN_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBN_Type.java
@@ -34,11 +34,11 @@ public class VBN_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = VBN.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.VBN");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBP.java
@@ -17,12 +17,12 @@ public class VBP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(VBP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBP_Type.java
@@ -34,11 +34,11 @@ public class VBP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = VBP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.VBP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBZ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBZ.java
@@ -17,12 +17,12 @@ public class VBZ extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(VBZ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBZ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VBZ_Type.java
@@ -34,11 +34,11 @@ public class VBZ_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = VBZ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.VBZ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VB_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VB_Type.java
@@ -34,11 +34,11 @@ public class VB_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = VB.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.VB");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VP.java
@@ -17,12 +17,12 @@ public class VP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(VP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/VP_Type.java
@@ -34,11 +34,11 @@ public class VP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = VP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.VP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WDT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WDT.java
@@ -17,12 +17,12 @@ public class WDT extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WDT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WDT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WDT_Type.java
@@ -34,11 +34,11 @@ public class WDT_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WDT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WDT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADJP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADJP.java
@@ -17,12 +17,12 @@ public class WHADJP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WHADJP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADJP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADJP_Type.java
@@ -34,11 +34,11 @@ public class WHADJP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WHADJP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WHADJP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADVP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADVP.java
@@ -17,12 +17,12 @@ public class WHADVP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WHADVP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADVP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHADVP_Type.java
@@ -34,11 +34,11 @@ public class WHADVP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WHADVP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WHADVP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHNP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHNP.java
@@ -17,12 +17,12 @@ public class WHNP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WHNP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHNP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHNP_Type.java
@@ -34,11 +34,11 @@ public class WHNP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WHNP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WHNP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHPP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHPP.java
@@ -17,12 +17,12 @@ public class WHPP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WHPP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHPP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WHPP_Type.java
@@ -34,11 +34,11 @@ public class WHPP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WHPP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WHPP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WP.java
@@ -17,12 +17,12 @@ public class WP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WPP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WPP.java
@@ -17,12 +17,12 @@ public class WPP extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WPP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WPP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WPP_Type.java
@@ -34,11 +34,11 @@ public class WPP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WPP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WPP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WP_Type.java
@@ -34,11 +34,11 @@ public class WP_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WRB.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WRB.java
@@ -17,12 +17,12 @@ public class WRB extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(WRB.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WRB_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/WRB_Type.java
@@ -34,11 +34,11 @@ public class WRB_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = WRB.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.WRB");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/X.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/X.java
@@ -17,12 +17,12 @@ public class X extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(X.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/XS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/XS.java
@@ -17,12 +17,12 @@ public class XS extends Constituent {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(XS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/XS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/XS_Type.java
@@ -34,11 +34,11 @@ public class XS_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = XS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.XS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/X_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent/X_Type.java
@@ -34,11 +34,11 @@ public class X_Type extends Constituent_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = X.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.X");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ABBREV.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ABBREV.java
@@ -17,12 +17,12 @@ public class ABBREV extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ABBREV.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ABBREV_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ABBREV_Type.java
@@ -34,11 +34,11 @@ public class ABBREV_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ABBREV.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.ABBREV");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ACOMP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ACOMP.java
@@ -17,12 +17,12 @@ public class ACOMP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ACOMP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ACOMP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ACOMP_Type.java
@@ -34,11 +34,11 @@ public class ACOMP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ACOMP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.ACOMP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVCL.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVCL.java
@@ -17,12 +17,12 @@ public class ADVCL extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ADVCL.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVCL_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVCL_Type.java
@@ -34,11 +34,11 @@ public class ADVCL_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ADVCL.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.ADVCL");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVMOD.java
@@ -17,12 +17,12 @@ public class ADVMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ADVMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ADVMOD_Type.java
@@ -34,11 +34,11 @@ public class ADVMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ADVMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.ADVMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AGENT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AGENT.java
@@ -17,12 +17,12 @@ public class AGENT extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(AGENT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AGENT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AGENT_Type.java
@@ -34,11 +34,11 @@ public class AGENT_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = AGENT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.AGENT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AMOD.java
@@ -17,12 +17,12 @@ public class AMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(AMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AMOD_Type.java
@@ -34,11 +34,11 @@ public class AMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = AMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.AMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/APPOS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/APPOS.java
@@ -17,12 +17,12 @@ public class APPOS extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(APPOS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/APPOS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/APPOS_Type.java
@@ -34,11 +34,11 @@ public class APPOS_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = APPOS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.APPOS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ATTR.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ATTR.java
@@ -17,12 +17,12 @@ public class ATTR extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ATTR.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ATTR_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/ATTR_Type.java
@@ -34,11 +34,11 @@ public class ATTR_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ATTR.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.ATTR");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUX0.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUX0.java
@@ -17,12 +17,12 @@ public class AUX0 extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(AUX0.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUX0_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUX0_Type.java
@@ -34,11 +34,11 @@ public class AUX0_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = AUX0.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.AUX0");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUXPASS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUXPASS.java
@@ -17,12 +17,12 @@ public class AUXPASS extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(AUXPASS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUXPASS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/AUXPASS_Type.java
@@ -34,11 +34,11 @@ public class AUXPASS_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = AUXPASS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.AUXPASS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CC.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CC.java
@@ -17,12 +17,12 @@ public class CC extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CC.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CCOMP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CCOMP.java
@@ -17,12 +17,12 @@ public class CCOMP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CCOMP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CCOMP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CCOMP_Type.java
@@ -34,11 +34,11 @@ public class CCOMP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CCOMP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.CCOMP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CC_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CC_Type.java
@@ -34,11 +34,11 @@ public class CC_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CC.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.CC");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COMPLM.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COMPLM.java
@@ -17,12 +17,12 @@ public class COMPLM extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(COMPLM.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COMPLM_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COMPLM_Type.java
@@ -34,11 +34,11 @@ public class COMPLM_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = COMPLM.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.COMPLM");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ.java
@@ -17,12 +17,12 @@ public class CONJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CONJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJP.java
@@ -17,12 +17,12 @@ public class CONJP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CONJP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJP_Type.java
@@ -34,11 +34,11 @@ public class CONJP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CONJP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.CONJP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ_Type.java
@@ -34,11 +34,11 @@ public class CONJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CONJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.CONJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ_YET.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ_YET.java
@@ -17,12 +17,12 @@ public class CONJ_YET extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CONJ_YET.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ_YET_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CONJ_YET_Type.java
@@ -34,11 +34,11 @@ public class CONJ_YET_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CONJ_YET.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.CONJ_YET");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COP.java
@@ -17,12 +17,12 @@ public class COP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(COP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/COP_Type.java
@@ -34,11 +34,11 @@ public class COP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = COP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.COP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJ.java
@@ -17,12 +17,12 @@ public class CSUBJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CSUBJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJPASS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJPASS.java
@@ -17,12 +17,12 @@ public class CSUBJPASS extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(CSUBJPASS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJPASS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJPASS_Type.java
@@ -34,11 +34,11 @@ public class CSUBJPASS_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CSUBJPASS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.CSUBJPASS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/CSUBJ_Type.java
@@ -34,11 +34,11 @@ public class CSUBJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = CSUBJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.CSUBJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DEP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DEP.java
@@ -17,12 +17,12 @@ public class DEP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(DEP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DEP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DEP_Type.java
@@ -34,11 +34,11 @@ public class DEP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = DEP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.DEP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DET.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DET.java
@@ -17,12 +17,12 @@ public class DET extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(DET.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DET_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DET_Type.java
@@ -34,11 +34,11 @@ public class DET_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = DET.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.DET");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DOBJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DOBJ.java
@@ -17,12 +17,12 @@ public class DOBJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(DOBJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DOBJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/DOBJ_Type.java
@@ -34,11 +34,11 @@ public class DOBJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = DOBJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.DOBJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependency.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependency.java
@@ -19,12 +19,12 @@ public class Dependency extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Dependency.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependency_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependency_Type.java
@@ -37,11 +37,11 @@ public class Dependency_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Dependency.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependent.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependent.java
@@ -19,12 +19,12 @@ public class Dependent extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Dependent.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependent_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Dependent_Type.java
@@ -37,11 +37,11 @@ public class Dependent_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Dependent.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependent");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/EXPL.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/EXPL.java
@@ -17,12 +17,12 @@ public class EXPL extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(EXPL.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/EXPL_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/EXPL_Type.java
@@ -34,11 +34,11 @@ public class EXPL_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = EXPL.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.EXPL");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Governor.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Governor.java
@@ -19,12 +19,12 @@ public class Governor extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Governor.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Governor_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/Governor_Type.java
@@ -37,11 +37,11 @@ public class Governor_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Governor.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Governor");
  
   /** @generated */

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/INFMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/INFMOD.java
@@ -17,12 +17,12 @@ public class INFMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(INFMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/INFMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/INFMOD_Type.java
@@ -34,11 +34,11 @@ public class INFMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = INFMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.INFMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/IOBJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/IOBJ.java
@@ -17,12 +17,12 @@ public class IOBJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(IOBJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/IOBJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/IOBJ_Type.java
@@ -34,11 +34,11 @@ public class IOBJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = IOBJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.IOBJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MARK.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MARK.java
@@ -17,12 +17,12 @@ public class MARK extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(MARK.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MARK_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MARK_Type.java
@@ -34,11 +34,11 @@ public class MARK_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = MARK.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.MARK");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MEASURE.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MEASURE.java
@@ -17,12 +17,12 @@ public class MEASURE extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(MEASURE.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MEASURE_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MEASURE_Type.java
@@ -34,11 +34,11 @@ public class MEASURE_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = MEASURE.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.MEASURE");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MWE.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MWE.java
@@ -17,12 +17,12 @@ public class MWE extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(MWE.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MWE_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/MWE_Type.java
@@ -34,11 +34,11 @@ public class MWE_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = MWE.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.MWE");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NEG.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NEG.java
@@ -17,12 +17,12 @@ public class NEG extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NEG.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NEG_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NEG_Type.java
@@ -34,11 +34,11 @@ public class NEG_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NEG.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.NEG");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NN.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NN.java
@@ -17,12 +17,12 @@ public class NN extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NN.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NN_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NN_Type.java
@@ -34,11 +34,11 @@ public class NN_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NN.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.NN");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NPADVMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NPADVMOD.java
@@ -17,12 +17,12 @@ public class NPADVMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NPADVMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NPADVMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NPADVMOD_Type.java
@@ -34,11 +34,11 @@ public class NPADVMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NPADVMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.NPADVMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJ.java
@@ -17,12 +17,12 @@ public class NSUBJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NSUBJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJPASS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJPASS.java
@@ -17,12 +17,12 @@ public class NSUBJPASS extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NSUBJPASS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJPASS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJPASS_Type.java
@@ -34,11 +34,11 @@ public class NSUBJPASS_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NSUBJPASS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.NSUBJPASS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NSUBJ_Type.java
@@ -34,11 +34,11 @@ public class NSUBJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NSUBJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.NSUBJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUM.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUM.java
@@ -17,12 +17,12 @@ public class NUM extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NUM.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUMBER.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUMBER.java
@@ -17,12 +17,12 @@ public class NUMBER extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NUMBER.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUMBER_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUMBER_Type.java
@@ -34,11 +34,11 @@ public class NUMBER_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NUMBER.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.NUMBER");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUM_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/NUM_Type.java
@@ -34,11 +34,11 @@ public class NUM_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NUM.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.NUM");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARATAXIS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARATAXIS.java
@@ -17,12 +17,12 @@ public class PARATAXIS extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PARATAXIS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARATAXIS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARATAXIS_Type.java
@@ -34,11 +34,11 @@ public class PARATAXIS_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PARATAXIS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PARATAXIS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARTMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARTMOD.java
@@ -17,12 +17,12 @@ public class PARTMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PARTMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARTMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PARTMOD_Type.java
@@ -34,11 +34,11 @@ public class PARTMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PARTMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PARTMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PCOMP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PCOMP.java
@@ -17,12 +17,12 @@ public class PCOMP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PCOMP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PCOMP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PCOMP_Type.java
@@ -34,11 +34,11 @@ public class PCOMP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PCOMP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PCOMP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POBJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POBJ.java
@@ -17,12 +17,12 @@ public class POBJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(POBJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POBJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POBJ_Type.java
@@ -34,11 +34,11 @@ public class POBJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = POBJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.POBJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSS.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSS.java
@@ -17,12 +17,12 @@ public class POSS extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(POSS.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSSESSIVE.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSSESSIVE.java
@@ -17,12 +17,12 @@ public class POSSESSIVE extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(POSSESSIVE.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSSESSIVE_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSSESSIVE_Type.java
@@ -34,11 +34,11 @@ public class POSSESSIVE_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = POSSESSIVE.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.POSSESSIVE");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSS_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/POSS_Type.java
@@ -34,11 +34,11 @@ public class POSS_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = POSS.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.POSS");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRECONJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRECONJ.java
@@ -17,12 +17,12 @@ public class PRECONJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PRECONJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRECONJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRECONJ_Type.java
@@ -34,11 +34,11 @@ public class PRECONJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PRECONJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PRECONJ");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRED.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRED.java
@@ -17,12 +17,12 @@ public class PRED extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PRED.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREDET.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREDET.java
@@ -17,12 +17,12 @@ public class PREDET extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PREDET.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREDET_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREDET_Type.java
@@ -34,11 +34,11 @@ public class PREDET_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PREDET.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PREDET");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRED_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRED_Type.java
@@ -34,11 +34,11 @@ public class PRED_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PRED.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PRED");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREP.java
@@ -17,12 +17,12 @@ public class PREP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PREP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREPC.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREPC.java
@@ -17,12 +17,12 @@ public class PREPC extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PREPC.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREPC_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREPC_Type.java
@@ -34,11 +34,11 @@ public class PREPC_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PREPC.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PREPC");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PREP_Type.java
@@ -34,11 +34,11 @@ public class PREP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PREP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PREP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRT.java
@@ -17,12 +17,12 @@ public class PRT extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PRT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PRT_Type.java
@@ -34,11 +34,11 @@ public class PRT_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PRT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PRT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PUNCT.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PUNCT.java
@@ -17,12 +17,12 @@ public class PUNCT extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PUNCT.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PUNCT_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PUNCT_Type.java
@@ -34,11 +34,11 @@ public class PUNCT_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PUNCT.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PUNCT");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PURPCL.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PURPCL.java
@@ -17,12 +17,12 @@ public class PURPCL extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PURPCL.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PURPCL_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/PURPCL_Type.java
@@ -34,11 +34,11 @@ public class PURPCL_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PURPCL.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.PURPCL");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/QUANTMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/QUANTMOD.java
@@ -17,12 +17,12 @@ public class QUANTMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(QUANTMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/QUANTMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/QUANTMOD_Type.java
@@ -34,11 +34,11 @@ public class QUANTMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = QUANTMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.QUANTMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/RCMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/RCMOD.java
@@ -17,12 +17,12 @@ public class RCMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(RCMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/RCMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/RCMOD_Type.java
@@ -34,11 +34,11 @@ public class RCMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = RCMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.RCMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REF.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REF.java
@@ -17,12 +17,12 @@ public class REF extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(REF.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REF_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REF_Type.java
@@ -34,11 +34,11 @@ public class REF_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = REF.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.REF");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REL.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REL.java
@@ -17,12 +17,12 @@ public class REL extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(REL.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REL_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/REL_Type.java
@@ -34,11 +34,11 @@ public class REL_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = REL.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.REL");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/TMOD.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/TMOD.java
@@ -17,12 +17,12 @@ public class TMOD extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(TMOD.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/TMOD_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/TMOD_Type.java
@@ -34,11 +34,11 @@ public class TMOD_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = TMOD.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.TMOD");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XCOMP.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XCOMP.java
@@ -17,12 +17,12 @@ public class XCOMP extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(XCOMP.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XCOMP_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XCOMP_Type.java
@@ -34,11 +34,11 @@ public class XCOMP_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = XCOMP.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.XCOMP");
 
 

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XSUBJ.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XSUBJ.java
@@ -17,12 +17,12 @@ public class XSUBJ extends Dependency {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(XSUBJ.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XSUBJ_Type.java
+++ b/common/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency/XSUBJ_Type.java
@@ -34,11 +34,11 @@ public class XSUBJ_Type extends Dependency_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = XSUBJ.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.XSUBJ");
 
 

--- a/common/src/main/java/eu/excitement/type/alignment/AlignedText.java
+++ b/common/src/main/java/eu/excitement/type/alignment/AlignedText.java
@@ -20,12 +20,12 @@ public class AlignedText extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(AlignedText.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/alignment/AlignedText_Type.java
+++ b/common/src/main/java/eu/excitement/type/alignment/AlignedText_Type.java
@@ -38,11 +38,11 @@ public class AlignedText_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = AlignedText.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.alignment.AlignedText");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/entailment/EntailmentMetadata.java
+++ b/common/src/main/java/eu/excitement/type/entailment/EntailmentMetadata.java
@@ -18,12 +18,12 @@ public class EntailmentMetadata extends TOP {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(EntailmentMetadata.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/entailment/EntailmentMetadata_Type.java
+++ b/common/src/main/java/eu/excitement/type/entailment/EntailmentMetadata_Type.java
@@ -37,11 +37,11 @@ public class EntailmentMetadata_Type extends TOP_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = EntailmentMetadata.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.entailment.EntailmentMetadata");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/entailment/Hypothesis.java
+++ b/common/src/main/java/eu/excitement/type/entailment/Hypothesis.java
@@ -19,12 +19,12 @@ public class Hypothesis extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Hypothesis.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/entailment/Hypothesis_Type.java
+++ b/common/src/main/java/eu/excitement/type/entailment/Hypothesis_Type.java
@@ -36,11 +36,11 @@ public class Hypothesis_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Hypothesis.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.entailment.Hypothesis");
 
 

--- a/common/src/main/java/eu/excitement/type/entailment/Pair.java
+++ b/common/src/main/java/eu/excitement/type/entailment/Pair.java
@@ -18,12 +18,12 @@ public class Pair extends TOP {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Pair.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/entailment/Pair_Type.java
+++ b/common/src/main/java/eu/excitement/type/entailment/Pair_Type.java
@@ -37,11 +37,11 @@ public class Pair_Type extends TOP_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Pair.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.entailment.Pair");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/entailment/Text.java
+++ b/common/src/main/java/eu/excitement/type/entailment/Text.java
@@ -19,12 +19,12 @@ public class Text extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Text.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/entailment/Text_Type.java
+++ b/common/src/main/java/eu/excitement/type/entailment/Text_Type.java
@@ -36,11 +36,11 @@ public class Text_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Text.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.entailment.Text");
 
 

--- a/common/src/main/java/eu/excitement/type/predicatetruth/ClauseTruth.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/ClauseTruth.java
@@ -18,12 +18,12 @@ public class ClauseTruth extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(ClauseTruth.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/predicatetruth/ClauseTruth_Type.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/ClauseTruth_Type.java
@@ -37,11 +37,11 @@ public class ClauseTruth_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = ClauseTruth.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.predicatetruth.ClauseTruth");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/predicatetruth/NegationAndUncertainty.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/NegationAndUncertainty.java
@@ -18,12 +18,12 @@ public class NegationAndUncertainty extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(NegationAndUncertainty.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/predicatetruth/NegationAndUncertainty_Type.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/NegationAndUncertainty_Type.java
@@ -37,11 +37,11 @@ public class NegationAndUncertainty_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = NegationAndUncertainty.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.predicatetruth.NegationAndUncertainty");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/predicatetruth/PredicateSignature.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/PredicateSignature.java
@@ -18,12 +18,12 @@ public class PredicateSignature extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PredicateSignature.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/predicatetruth/PredicateSignature_Type.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/PredicateSignature_Type.java
@@ -35,11 +35,11 @@ public class PredicateSignature_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PredicateSignature.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.predicatetruth.PredicateSignature");
 
 

--- a/common/src/main/java/eu/excitement/type/predicatetruth/PredicateTruth.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/PredicateTruth.java
@@ -18,12 +18,12 @@ public class PredicateTruth extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(PredicateTruth.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/predicatetruth/PredicateTruth_Type.java
+++ b/common/src/main/java/eu/excitement/type/predicatetruth/PredicateTruth_Type.java
@@ -37,11 +37,11 @@ public class PredicateTruth_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = PredicateTruth.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.predicatetruth.PredicateTruth");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/semanticrole/Argument.java
+++ b/common/src/main/java/eu/excitement/type/semanticrole/Argument.java
@@ -19,12 +19,12 @@ public class Argument extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Argument.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/semanticrole/Argument_Type.java
+++ b/common/src/main/java/eu/excitement/type/semanticrole/Argument_Type.java
@@ -37,11 +37,11 @@ public class Argument_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Argument.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.semanticrole.Argument");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/semanticrole/Predicate.java
+++ b/common/src/main/java/eu/excitement/type/semanticrole/Predicate.java
@@ -21,12 +21,12 @@ public class Predicate extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Predicate.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/semanticrole/Predicate_Type.java
+++ b/common/src/main/java/eu/excitement/type/semanticrole/Predicate_Type.java
@@ -39,11 +39,11 @@ public class Predicate_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Predicate.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.semanticrole.Predicate");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/temporal/Date.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Date.java
@@ -17,12 +17,12 @@ public class Date extends TemporalExpression {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Date.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/temporal/Date_Type.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Date_Type.java
@@ -34,11 +34,11 @@ public class Date_Type extends TemporalExpression_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Date.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.temporal.Date");
 
 

--- a/common/src/main/java/eu/excitement/type/temporal/DefaultTimeOfText.java
+++ b/common/src/main/java/eu/excitement/type/temporal/DefaultTimeOfText.java
@@ -18,12 +18,12 @@ public class DefaultTimeOfText extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(DefaultTimeOfText.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/temporal/DefaultTimeOfText_Type.java
+++ b/common/src/main/java/eu/excitement/type/temporal/DefaultTimeOfText_Type.java
@@ -37,11 +37,11 @@ public class DefaultTimeOfText_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = DefaultTimeOfText.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.temporal.DefaultTimeOfText");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/temporal/Duration.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Duration.java
@@ -17,12 +17,12 @@ public class Duration extends TemporalExpression {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Duration.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/temporal/Duration_Type.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Duration_Type.java
@@ -34,11 +34,11 @@ public class Duration_Type extends TemporalExpression_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Duration.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.temporal.Duration");
 
 

--- a/common/src/main/java/eu/excitement/type/temporal/Set.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Set.java
@@ -18,12 +18,12 @@ public class Set extends TemporalExpression {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Set.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/temporal/Set_Type.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Set_Type.java
@@ -35,11 +35,11 @@ public class Set_Type extends TemporalExpression_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Set.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.temporal.Set");
 
 

--- a/common/src/main/java/eu/excitement/type/temporal/TemporalExpression.java
+++ b/common/src/main/java/eu/excitement/type/temporal/TemporalExpression.java
@@ -18,12 +18,12 @@ public class TemporalExpression extends Annotation {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(TemporalExpression.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/temporal/TemporalExpression_Type.java
+++ b/common/src/main/java/eu/excitement/type/temporal/TemporalExpression_Type.java
@@ -37,11 +37,11 @@ public class TemporalExpression_Type extends Annotation_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = TemporalExpression.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.temporal.TemporalExpression");
  
   /** @generated */

--- a/common/src/main/java/eu/excitement/type/temporal/Time.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Time.java
@@ -18,12 +18,12 @@ public class Time extends TemporalExpression {
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = JCasRegistry.register(Time.class);
   /** @generated
    * @ordered 
    */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int type = typeIndexID;
   /** @generated  */
   @Override

--- a/common/src/main/java/eu/excitement/type/temporal/Time_Type.java
+++ b/common/src/main/java/eu/excitement/type/temporal/Time_Type.java
@@ -35,11 +35,11 @@ public class Time_Type extends TemporalExpression_Type {
   	  }
     };
   /** @generated */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static int typeIndexID = Time.typeIndexID;
   /** @generated 
      @modifiable */
-  @SuppressWarnings ("hiding")
+  //@SuppressWarnings ("hiding")
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.temporal.Time");
 
 

--- a/core/src/main/java/eu/excitementproject/eop/core/component/distance/FixedWeightTokenEditDistance.java
+++ b/core/src/main/java/eu/excitementproject/eop/core/component/distance/FixedWeightTokenEditDistance.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import org.apache.uima.jcas.JCas;
-import org.apache.uima.cas.CASException;
+//import org.apache.uima.cas.CASException;
 import org.apache.uima.cas.text.AnnotationIndex;
 import org.apache.uima.jcas.tcas.Annotation;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -243,7 +243,7 @@ public class FixedWeightTokenEditDistance implements DistanceCalculation {
      */
     public DistanceValue distance(List<Token> source, List<Token> target ) throws ArithmeticException {
         	
-    	DistanceValue distanceValue = new EditDistanceValue(0, false, 0);
+    	//DistanceValue distanceValue = new EditDistanceValue(0, false, 0);
     	
     	// distanceTable is a table with sizeSource+1 rows and sizeTarget+1 columns
     	double[][] distanceTable = new double[source.size() + 1][target.size() + 1];

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,14 @@
 
   <repositories>
 	<repository>
- 		<id>central</id>
+ 		<id>FBK</id>
      	<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
      	<snapshots>
        		<enabled>false</enabled>
      	</snapshots>
  	</repository>
    	<repository>
-   		<id>snapshots</id>
+   		<id>FBKsnapshots</id>
      	<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
       	<releases>
        		<enabled>false</enabled>
@@ -83,33 +83,38 @@
   	</repository>
   </repositories>
   
+   
   <pluginRepositories>
  	<pluginRepository>
-   	<id>central</id>
+   	<id>FBK</id>
   	<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
    	<snapshots>
    		<enabled>false</enabled>
   	</snapshots>
   </pluginRepository>
   	<pluginRepository>
-		<id>snapshots</id>
+		<id>FBKsnapshots</id>
   		<url>http://hlt-services4.fbk.eu:8080/artifactory/repo</url>
   		<releases>
    			<enabled>false</enabled>
   		</releases>
    	</pluginRepository>
   </pluginRepositories>
-
+ 
   <build>
   	<plugins>
 		<plugin>
         		<groupId>org.apache.maven.plugins</groupId>
         		<artifactId>maven-compiler-plugin</artifactId>
+        		<version>2.5.1</version>
         		<configuration>
-            			<source>1.6</source>
-            			<target>1.6</target>
+            			<source>1.7</source>
+            			<target>1.7</target>
         		</configuration>
     		</plugin>
   	</plugins>
   </build>
+  <properties>
+  	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>


### PR DESCRIPTION
POM changes
- changed JDK compiler version to 1.7 (NOTE: you now need JDK 1.7 to build it. If you want, you can change <source> and <target> in topmost POM to compile it in 1.6.) 
- changed FBK Maven repository ID to something else than "central", to un-hide the central repository 
- specified POM resource encoding as UTF-8, to remove maven build warnings 
- specified maven plugin versions, to remove maven build warnings 

Code changes 
- removed unneeded @Suppress to remove warnings 
- removed unneeded import and variables to remove warnings
