### PR TITLE
removing a warning 

### DIFF
--- a/core/src/main/java/eu/excitementproject/eop/core/component/lexicalknowledge/derivbase/Tuple.java
+++ b/core/src/main/java/eu/excitementproject/eop/core/component/lexicalknowledge/derivbase/Tuple.java
@@ -103,9 +103,10 @@ public class Tuple<E> implements Serializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        Tuple<E> tuple = (Tuple<E>) o;
-
+        
+        @SuppressWarnings("unchecked") // added to suppress warning - gil 
+		Tuple<E> tuple = (Tuple<E>) o;
+        
         if (this.a != null ? !a.equals(tuple.a) : tuple.a != null) {
             return false;
         }


### PR DESCRIPTION
A warning was left over; simply suppressed it, since the type is already checked.
