### PR TITLE
checkstyle, findbugs, pmd

### DIFF
--- a/config/code-quality-metrics/checkstyle.xml
+++ b/config/code-quality-metrics/checkstyle.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<!--
+
+  Checks for Javadoc comments only.
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  http://checkstyle.sourceforge.net
+
+  To disable a check, just comment it out
+
+-->
+
+<module name="Checker">
+
+	<module name="JavadocPackage"/>
+
+	<module name="TreeWalker">
+ 	
+		<!-- Checks for Javadoc comments. -->
+		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+
+                <!-- Checks the Javadoc of a method or constructor. -->
+		<module name="JavadocMethod">
+			<property name="scope" value="public"/>
+			<!-- whether to ignore errors when a method has parameters but does not have
+			matching param tags in the javadoc. -->
+			<property name="allowMissingParamTags" value="true"/>
+			<!-- whether to ignore errors when a method declares that it throws exceptions
+			but does have matching throws tags in the javadoc. -->
+			<property name="allowMissingThrowsTags" value="true"/>
+			<!-- whether to ignore errors when a method returns non-void type does have a
+			return tag in the javadoc. -->
+			<property name="allowMissingReturnTag" value="true"/>
+		</module>
+
+                <!-- Checks Javadoc comments for class and interface definitions. 
+		By default, does not check for author or version tags.-->
+		<module name="JavadocType">
+			<property name="scope" value="public"/>
+			<!-- whether to ignore errors when a class has type parameters but does not have
+			matching param tags in the javadoc.-->
+			<property name="allowMissingParamTags" value="true"/>
+		</module>
+
+                <!-- Checks that variables have Javadoc comments. -->
+		<!--
+		<module name="JavadocVariable">
+			<property name="scope" value="package"/>
+		</module>
+		-->
+
+                <!-- Validates Javadoc comments to help ensure they are well formed. -->
+		<!--
+		<module name="JavadocStyle">
+			<property name="scope" value="public"/>
+		</module>
+		-->
+	</module> 
+
+</module>
+

--- a/pom.xml
+++ b/pom.xml
@@ -253,8 +253,8 @@
 			      </descriptors>
 			    </configuration>
 			
-			    <!-- se commentato, eseguire mvn assembly:assembly,
-			         altrimenti mvn package 
+			    <!-- when commented, run mvn assembly:assembly,
+			         otherwise mvn package 
 			    
 			    <executions>
 			      <execution>
@@ -266,11 +266,68 @@
 			      </execution>
 			    </executions>
 			    -->
-			    
-			</plugin>
+		</plugin>
+
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-checkstyle-plugin</artifactId>
+			<version>2.10</version>
+			<configuration>
+				<configLocation>./config/code-quality-metrics/checkstyle.xml</configLocation>
+					<excludes>**/gui/**/*</excludes>
+			</configuration>
+		</plugin>
+	      	
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-pmd-plugin</artifactId>
+			<version>3.0.1</version>
+			<configuration>
+				<targetJdk>1.7</targetJdk>
+				<excludes>
+					<exclude>**/gui/**/*</exclude>
+				</excludes>
+			</configuration>
+		</plugin>
+	      
+		<plugin>
+			<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>2.5.2</version>
+				<configuration>
+					<xmlOutput>true</xmlOutput>
+					<onlyAnalyze>eop.core.*,eop.lap.*,eop.common.*,eop.biutee.*,eop.transformations.*,eop.distsim.*</onlyAnalyze>
+				</configuration>
+		</plugin>
+		 
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-javadoc-plugin</artifactId>
+			<version>2.9</version>
+			<configuration>
+				<sourceFileExcludes>
+					<exclude>eop/gui/*</exclude>
+				</sourceFileExcludes>
+				<aggregate>true</aggregate>         
+			</configuration>
+		</plugin>
+		  		
+ 	</plugins>
     		
-  	</plugins>
   </build>
+
+  <reporting>
+  
+	<plugins>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-jxr-plugin</artifactId>
+			<version>2.3</version>
+		</plugin>	      
+	</plugins>
+    
+  </reporting>
+
   <properties>
   	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
Update the pom.xml file to let maven use checkstyle, findbugs, pmd; these tools are used to check the quality of the EOP code

Add the checkstyle.xml file to configure the checkstyle tool
