### PR TITLE
Removing MSTParser artifacts from POM, and related codes. 

### DIFF
--- a/lap/pom.xml
+++ b/lap/pom.xml
@@ -18,11 +18,13 @@
 			<name>DKPro repository</name>
           	<url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-releases</url>
      	</repository>
+     <!--  
      	<repository>
      		<id>ukp-oss-snapshot</id>
      		<name>DKPro snapshot repository (for 1.5.0 access)</name>
      		<url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots</url> 
      	</repository>
+     --> 
   	</repositories>
   	
    	<pluginRepositories>
@@ -199,39 +201,6 @@
     		</artifactId>
     	</dependency>
     	<dependency>
-    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
-    		<artifactId>
-    			de.tudarmstadt.ukp.dkpro.core.mstparser-asl
-    		</artifactId>
-    		<version>1.5.0-SNAPSHOT</version>
-    	</dependency>
-    	<dependency>
-    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
-    		<artifactId>
-    			de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-en-default
-    		</artifactId>
-    		<version>20121910.0</version>
-    	</dependency>
-    	<dependency>
-    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
-    		<artifactId>
-    			de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-de-default
-    		</artifactId>
-    		<version>20130304.0</version>
-    	</dependency>
-    	
-    	<!--  1G big model for German MST parser: commented out for prevent unneeded downloads -->
-    	<!--  Include them if you need  DE-LONG variant model for MSTParserDE -->
-    	<!-- 
-    	<dependency>
-    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
-    		<artifactId>
-    			de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-de-long
-    		</artifactId>
-    		<version>20130301.0</version>
-    	</dependency>
-    	-->
-    	<dependency>
             <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
             <artifactId>
                 de.tudarmstadt.ukp.dkpro.core.maltparser-model-parser-de-linear
@@ -245,6 +214,44 @@
     		</artifactId>
     		<version>20130404.1</version>
     	</dependency>
+    	    	
+    	<!-- We are not using MST parser for 1.0 release.  -->
+    	<!--  
+    	
+    	<dependency>
+    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+    		<artifactId>
+    			de.tudarmstadt.ukp.dkpro.core.mstparser-asl
+    		</artifactId>
+    		<version>1.5.0-SNAPSHOT</version>
+    	</dependency>
+    	<dependency>
+    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+    		<artifactId>
+    			de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-en-default
+    		</artifactId>
+    		<version>20121910.0</version>
+    	</dependency>
+    	
+    	<dependency>
+    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+    		<artifactId>
+    			de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-de-default
+    		</artifactId>
+    		<version>20130304.0</version>
+    	</dependency>
+    	--> 
+    	<!--  1G big model for German MST parser: commented out for prevent unneeded downloads -->
+    	<!--  Include them if you need  DE-LONG variant model for MSTParserDE -->
+    	<!-- 
+    	<dependency>
+    		<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+    		<artifactId>
+    			de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-de-long
+    		</artifactId>
+    		<version>20130301.0</version>
+    	</dependency>
+    	-->
  	</dependencies>
 
     <dependencyManagement>

--- a/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MSTParserDE.java
+++ b/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MSTParserDE.java
@@ -1,71 +1,75 @@
 package eu.excitementproject.eop.lap.dkpro;
 
-import java.util.Map;
-
-import eu.excitementproject.eop.lap.LAPException;
-
-/**
- * <P> 
- * This LAPAccess implementation provides LAPAcess interface for German by using 
- * Sentence Splitter + Tree tagger + MSTParser. 
- * 
- * <P>
- * It will use default German Tagger model, but you can select Parser model by the "variant" string in the constructor. 
- * (variant, is a model ID, that is used by DKPro parser AE) 
- * 
- * @author Gil 
- *
- */
-
-
-public class MSTParserDE extends MSTParserEN {
-
-	/**
-	 * Without any argument, this will initiate the instance with German default 
-	 * model for MST Parser, with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
-	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
-	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is actually faster). 
-	 *  
-	 * @throws LAPException
-	 */
-	public MSTParserDE() throws LAPException
-	{
-		super(); 
-		this.languageIdentifier="DE"; // setting LangID. Other things will be handled accordingly in base class
-	}
-	
-	/**
-	 * <P> 
-	 * This constructor will initiate this MSTParser based LAP instance with the given PARSER_MODEL_VARIANT. 
-	 * (Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
-	 * 
-	 * <P> 
-	 * This will initiate the instance with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
-	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
-	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is faster).
-	 * 
-	 * @param listAEDescriptorsArgs (For German, "long" and "default" model variants are included in the first release.) This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. The value can be null, for default arguments. 
-	 * @throws LAPException
-	 */
-	public MSTParserDE(Map<String,String> listAEDescriptorsArgs) throws LAPException 
-	{
-		super(listAEDescriptorsArgs);
-		this.languageIdentifier="DE"; // setting LangID. Other things will be handled accordingly in base class
-	}
-	
-	/**
-	 * <P> 
-	 * Full constructor, that accepts model Varient and view names. If you use this LAP for EOP EDAs (e.g. where you need TextView & Hypothesis View), you can simply call the constructor without view names (since their default is Default, TView and HView). 
-	 * ModelVarient will load the desinated model-varient. 	(Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
-	 * 
-	 * @param views String array of "view names". Once initialized, the instance can only annotate this "previously given" Views only. (See LAP_ImplBaseAE for explanation). 
-	 * @param listAEDescriptorsArgs (For German, "long" and "default" model variants are included in the first release.) This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. 
-	 * @throws LAPException
-	 */
-	public MSTParserDE(String[] views, Map<String,String> listAEDescriptorsArgs ) throws LAPException
-	{
-		super(views, listAEDescriptorsArgs); 
-		this.languageIdentifier="DE"; // setting LangID. Other things will be handled accordingly in base class
-	}
-	
-}
+//FROZEN
+//WE will revive MSTParser after DKPRO 1.5.0 gets stable and uploaded to Maven Central 
+//
+//
+//import java.util.Map;
+//
+//import eu.excitementproject.eop.lap.LAPException;
+//
+///**
+// * <P> 
+// * This LAPAccess implementation provides LAPAcess interface for German by using 
+// * Sentence Splitter + Tree tagger + MSTParser. 
+// * 
+// * <P>
+// * It will use default German Tagger model, but you can select Parser model by the "variant" string in the constructor. 
+// * (variant, is a model ID, that is used by DKPro parser AE) 
+// * 
+// * @author Gil 
+// *
+// */
+//
+//
+//public class MSTParserDE extends MSTParserEN {
+//
+//	/**
+//	 * Without any argument, this will initiate the instance with German default 
+//	 * model for MST Parser, with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
+//	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
+//	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is actually faster). 
+//	 *  
+//	 * @throws LAPException
+//	 */
+//	public MSTParserDE() throws LAPException
+//	{
+//		super(); 
+//		this.languageIdentifier="DE"; // setting LangID. Other things will be handled accordingly in base class
+//	}
+//	
+//	/**
+//	 * <P> 
+//	 * This constructor will initiate this MSTParser based LAP instance with the given PARSER_MODEL_VARIANT. 
+//	 * (Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
+//	 * 
+//	 * <P> 
+//	 * This will initiate the instance with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
+//	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
+//	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is faster).
+//	 * 
+//	 * @param listAEDescriptorsArgs (For German, "long" and "default" model variants are included in the first release.) This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. The value can be null, for default arguments. 
+//	 * @throws LAPException
+//	 */
+//	public MSTParserDE(Map<String,String> listAEDescriptorsArgs) throws LAPException 
+//	{
+//		super(listAEDescriptorsArgs);
+//		this.languageIdentifier="DE"; // setting LangID. Other things will be handled accordingly in base class
+//	}
+//	
+//	/**
+//	 * <P> 
+//	 * Full constructor, that accepts model Varient and view names. If you use this LAP for EOP EDAs (e.g. where you need TextView & Hypothesis View), you can simply call the constructor without view names (since their default is Default, TView and HView). 
+//	 * ModelVarient will load the desinated model-varient. 	(Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
+//	 * 
+//	 * @param views String array of "view names". Once initialized, the instance can only annotate this "previously given" Views only. (See LAP_ImplBaseAE for explanation). 
+//	 * @param listAEDescriptorsArgs (For German, "long" and "default" model variants are included in the first release.) This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. 
+//	 * @throws LAPException
+//	 */
+//	public MSTParserDE(String[] views, Map<String,String> listAEDescriptorsArgs ) throws LAPException
+//	{
+//		super(views, listAEDescriptorsArgs); 
+//		this.languageIdentifier="DE"; // setting LangID. Other things will be handled accordingly in base class
+//	}
+//	
+//}

--- a/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MSTParserEN.java
+++ b/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MSTParserEN.java
@@ -1,113 +1,117 @@
 package eu.excitementproject.eop.lap.dkpro;
 
-import static org.uimafit.factory.AnalysisEngineFactory.createPrimitiveDescription;
-
-import java.util.Map;
-
-import org.apache.uima.analysis_engine.AnalysisEngineDescription;
-import org.apache.uima.resource.ResourceInitializationException;
-
-import de.tudarmstadt.ukp.dkpro.core.mstparser.MSTParser;
-import de.tudarmstadt.ukp.dkpro.core.tokit.BreakIteratorSegmenter;
-import de.tudarmstadt.ukp.dkpro.core.treetagger.TreeTaggerPosLemmaTT4J;
-
-import eu.excitementproject.eop.lap.LAPException;
-import eu.excitementproject.eop.lap.lappoc.LAP_ImplBaseAE;
-
-/**
- * This LAPAccess implementation provides LAPAcess interface for English by using 
- * Sentence Splitter + Tree tagger + MSTParser. 
- * 
- * <P>
- * It will use default English Tree Tagger model, but you can select Parser model by the "variant" string in the constructor. 
- * (variant, is a model ID, that is used by DKPro parser AE) 
- * 
- * 
- * // TODO BUG: For the moment, super() is called before modelVariant is set. Thus it fails to update model variant. Need to think a best way to do this. 
- * // TODO (update exception comment on modelVariant, after a good checking). 
- * @author Gil
- */
-public class MSTParserEN extends LAP_ImplBaseAE {
-
-	/**
-	 * Without any argument, this will initiate the instance with English default 
-	 * model for MST Parser, with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
-	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
-	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is actually faster). 
-	 * 
-	 * @throws LAPException
-	 */
-	public MSTParserEN() throws LAPException 
-	{
-		this(null); // no arguments passed to listAEDescriptors -- means default model
-	}
-	
-	/**
-	 * <P> 
-	 * This constructor will initiate this MSTParser based LAP instance with the given modelVarient. 
-	 * (Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
-	 * 
-	 * <P> 
-	 * This will initiate the instance with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
-	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
-	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is faster).
-	 * 
-	 * @param listAEDescriptorsArgs This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. 
-	 * @throws LAPException
-	 */
-	public MSTParserEN(Map<String,String> listAEDescriptorsArgs) throws LAPException 
-	{
-		super(listAEDescriptorsArgs); 
-		languageIdentifier = "EN"; // set languageIdentifer
-		// REMOVED: use listAEDescriptorArgs instead.	//this.modelVariant = modelVarient; // this will determine model-"variant" for model loading 
-	}
-	
-	/**
-	 * <P> 
-	 * Full constructor, that accepts model Varient and view names. If you use this LAP for EOP EDAs (e.g. where you need TextView & Hypothesis View), you can simply call the constructor without view names (since their default is Default, TView and HView). 
-	 * ModelVarient will load the desinated model-varient. 	(Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
-	 * 
-	 * @param views String array of "view names". Once initialized, the instance can only annotate this "previously given" Views only. (See LAP_ImplBaseAE for explanation). 
-	 * @param listAEDescriptorsArgs This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. 
-	 * @throws LAPException
-	 */
-	public MSTParserEN(String[] views, Map<String,String> listAEDescriptorsArgs) throws LAPException 
-	{
-		super(views, listAEDescriptorsArgs);
-		languageIdentifier = "EN"; 
-		// REMOVED: use listAEDescriptorArgs instead // this.modelVariant = modelVarient; 
-	}
-	
-	@Override
-	public AnalysisEngineDescription[] listAEDescriptors(Map<String, String> args) throws LAPException {
-
-		// This example uses DKPro BreakIterSegmenter, TreeTagger, and MSTParser 
-		// simply return them in an array, with order. (sentence segmentation first, then tagging, then parsing) 
-		AnalysisEngineDescription[] descArr = new AnalysisEngineDescription[3];
-		String modelVariant=null; 
-
-	    if ( (args != null) && (args.get("PARSER_MODEL_VARIANT") != ""))
-	    { // parser model argument passed in from the constructor. 
-	    	modelVariant = args.get("PARSER_MODEL_VARIANT"); 
-	    }
-	    
-		try 
-		{
-			descArr[0] = createPrimitiveDescription(BreakIteratorSegmenter.class);
-			descArr[1] = createPrimitiveDescription(TreeTaggerPosLemmaTT4J.class); 
-			descArr[2] = createPrimitiveDescription(MSTParser.class,
-					MSTParser.PARAM_VARIANT, modelVariant); 
-		}
-		catch (ResourceInitializationException e)
-		{
-			throw new LAPException("Unable to create AE descriptions", e); 
-		}
-		
-		return descArr; 
-				
-	}
-
-	//private String modelVariant; 
-	
-}
-
+// FROZEN
+// WE will revive MSTParser after DKPRO 1.5.0 gets stable and uploaded to Maven Central 
+// 
+//
+//import static org.uimafit.factory.AnalysisEngineFactory.createPrimitiveDescription;
+//
+//import java.util.Map;
+//
+//import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+//import org.apache.uima.resource.ResourceInitializationException;
+//
+//import de.tudarmstadt.ukp.dkpro.core.mstparser.MSTParser;
+//import de.tudarmstadt.ukp.dkpro.core.tokit.BreakIteratorSegmenter;
+//import de.tudarmstadt.ukp.dkpro.core.treetagger.TreeTaggerPosLemmaTT4J;
+//
+//import eu.excitementproject.eop.lap.LAPException;
+//import eu.excitementproject.eop.lap.lappoc.LAP_ImplBaseAE;
+//
+///**
+// * This LAPAccess implementation provides LAPAcess interface for English by using 
+// * Sentence Splitter + Tree tagger + MSTParser. 
+// * 
+// * <P>
+// * It will use default English Tree Tagger model, but you can select Parser model by the "variant" string in the constructor. 
+// * (variant, is a model ID, that is used by DKPro parser AE) 
+// * 
+// * 
+// * // TODO BUG: For the moment, super() is called before modelVariant is set. Thus it fails to update model variant. Need to think a best way to do this. 
+// * // TODO (update exception comment on modelVariant, after a good checking). 
+// * @author Gil
+// */
+//public class MSTParserEN extends LAP_ImplBaseAE {
+//
+//	/**
+//	 * Without any argument, this will initiate the instance with English default 
+//	 * model for MST Parser, with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
+//	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
+//	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is actually faster). 
+//	 * 
+//	 * @throws LAPException
+//	 */
+//	public MSTParserEN() throws LAPException 
+//	{
+//		this(null); // no arguments passed to listAEDescriptors -- means default model
+//	}
+//	
+//	/**
+//	 * <P> 
+//	 * This constructor will initiate this MSTParser based LAP instance with the given modelVarient. 
+//	 * (Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
+//	 * 
+//	 * <P> 
+//	 * This will initiate the instance with the capability of annotating the "three views" (Default, TextView & HypothesisView). 
+//	 * If you need only need to annotate a specific view (e.g. Default only, not for T & H View, etc) 
+//	 * call the full constructor with two arguments. (e.g. if you give one view only, its initialization is faster).
+//	 * 
+//	 * @param listAEDescriptorsArgs This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. 
+//	 * @throws LAPException
+//	 */
+//	public MSTParserEN(Map<String,String> listAEDescriptorsArgs) throws LAPException 
+//	{
+//		super(listAEDescriptorsArgs); 
+//		languageIdentifier = "EN"; // set languageIdentifer
+//		// REMOVED: use listAEDescriptorArgs instead.	//this.modelVariant = modelVarient; // this will determine model-"variant" for model loading 
+//	}
+//	
+//	/**
+//	 * <P> 
+//	 * Full constructor, that accepts model Varient and view names. If you use this LAP for EOP EDAs (e.g. where you need TextView & Hypothesis View), you can simply call the constructor without view names (since their default is Default, TView and HView). 
+//	 * ModelVarient will load the desinated model-varient. 	(Thus: de.tudarmstadt.ukp.dkpro.core.mstparser-model-parser-[LANGID]-[modelVarient] ) 
+//	 * 
+//	 * @param views String array of "view names". Once initialized, the instance can only annotate this "previously given" Views only. (See LAP_ImplBaseAE for explanation). 
+//	 * @param listAEDescriptorsArgs This argument holds the arguments that will be passed directly to the listAEDescriptorsArgs() which will generate AE descriptors. The arguments are depending on the implementation of listAEDescriptors(). Only one argument is know to this pipeline. PARSER_MODEL_VARIANT: which will load corresponding model variant of MST parser. 
+//	 * @throws LAPException
+//	 */
+//	public MSTParserEN(String[] views, Map<String,String> listAEDescriptorsArgs) throws LAPException 
+//	{
+//		super(views, listAEDescriptorsArgs);
+//		languageIdentifier = "EN"; 
+//		// REMOVED: use listAEDescriptorArgs instead // this.modelVariant = modelVarient; 
+//	}
+//	
+//	@Override
+//	public AnalysisEngineDescription[] listAEDescriptors(Map<String, String> args) throws LAPException {
+//
+//		// This example uses DKPro BreakIterSegmenter, TreeTagger, and MSTParser 
+//		// simply return them in an array, with order. (sentence segmentation first, then tagging, then parsing) 
+//		AnalysisEngineDescription[] descArr = new AnalysisEngineDescription[3];
+//		String modelVariant=null; 
+//
+//	    if ( (args != null) && (args.get("PARSER_MODEL_VARIANT") != ""))
+//	    { // parser model argument passed in from the constructor. 
+//	    	modelVariant = args.get("PARSER_MODEL_VARIANT"); 
+//	    }
+//	    
+//		try 
+//		{
+//			descArr[0] = createPrimitiveDescription(BreakIteratorSegmenter.class);
+//			descArr[1] = createPrimitiveDescription(TreeTaggerPosLemmaTT4J.class); 
+//			descArr[2] = createPrimitiveDescription(MSTParser.class,
+//					MSTParser.PARAM_VARIANT, modelVariant); 
+//		}
+//		catch (ResourceInitializationException e)
+//		{
+//			throw new LAPException("Unable to create AE descriptions", e); 
+//		}
+//		
+//		return descArr; 
+//				
+//	}
+//
+//	//private String modelVariant; 
+//	
+//}
+//

--- a/lap/src/main/java/eu/excitementproject/eop/lap/lappoc/DKProTest.java
+++ b/lap/src/main/java/eu/excitementproject/eop/lap/lappoc/DKProTest.java
@@ -21,7 +21,7 @@ import static org.uimafit.factory.AnalysisEngineFactory.*;
 import org.uimafit.component.xwriter.CASDumpWriter;
 import org.uimafit.factory.AggregateBuilder;
 import de.tudarmstadt.ukp.dkpro.core.treetagger.*; 
-import de.tudarmstadt.ukp.dkpro.core.mstparser.MSTParser; 
+//import de.tudarmstadt.ukp.dkpro.core.mstparser.MSTParser; 
 //import static org.uimafit.pipeline.SimplePipeline.*;
 //import static org.uimafit.factory.TypeSystemDescriptionFactory.*; 
 //import static org.uimafit.factory.JCasFactory.*; 
@@ -45,7 +45,7 @@ public class DKProTest {
 		AnalysisEngineDescription seg = createPrimitiveDescription(BreakIteratorSegmenter.class);
 		//AnalysisEngineDescription tagger = createPrimitiveDescription(OpenNlpPosTagger.class);
 		AnalysisEngineDescription lemma = createPrimitiveDescription(TreeTaggerPosLemmaTT4J.class); 
-		AnalysisEngineDescription parse = createPrimitiveDescription(MSTParser.class); 
+		//AnalysisEngineDescription parse = createPrimitiveDescription(MSTParser.class); 
 		AnalysisEngineDescription cc = createPrimitiveDescription(
 			         CASDumpWriter.class,
 			         CASDumpWriter.PARAM_OUTPUT_FILE, "target/output.txt");
@@ -77,7 +77,7 @@ public class DKProTest {
 		builder.add(seg, "_InitialView", "TextView");
 		//builder.add(tagger, "_InitialView", "TextView"); 
 		builder.add(lemma, "_InitialView", "TextView");
-		builder.add(parse, "_InitialView", "TextView");  
+		//builder.add(parse, "_InitialView", "TextView");  
 		builder.add(cc); 
 		
 		AnalysisEngine textViewAE = builder.createAggregate(); 
@@ -93,13 +93,13 @@ public class DKProTest {
 		// b) Dependency on this big model is commented out on the upstream LAP POM.xml. 
 		//    un-comment that dependency in POM to mark dependency on the long model. 
 		//    if the model is not found, DKPro MST parser will load up default model. 
-		AnalysisEngineDescription parse2 = createPrimitiveDescription(MSTParser.class,
-				MSTParser.PARAM_VARIANT, "long"); 
+		//AnalysisEngineDescription parse2 = createPrimitiveDescription(MSTParser.class,
+		//		MSTParser.PARAM_VARIANT, "long"); 
 	
 		AggregateBuilder b = new AggregateBuilder(); 
 		b.add(seg); 
 		b.add(lemma); 
-		b.add(parse2); 
+		//b.add(parse2); 
 		b.add(cc); 
 
 		AnalysisEngine bAE = b.createAggregate(); 

--- a/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/MSTParserDETest.java
+++ b/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/MSTParserDETest.java
@@ -1,53 +1,56 @@
 package eu.excitementproject.eop.lap.dkpro;
 
-import static org.junit.Assert.*;
-
-import org.apache.uima.jcas.JCas;
-import org.junit.Test;
-
-import eu.excitementproject.eop.lap.LAPAccess;
-import eu.excitementproject.eop.lap.LAPException;
-import eu.excitementproject.eop.lap.PlatformCASProber;
-
-public class MSTParserDETest {
-
-	@Test
-	public void test() {
-		// Generating a Single CAS 
-		LAPAccess lap = null; 
-		JCas aJCas = null; 
-
-		try {
-			lap = new MSTParserDE(); // same as ("default"); 
-			//lap = new MSTParserDE("long"); 
-			
-			// one of the LAPAccess interface: that generates single TH CAS. 
-			aJCas = lap.generateSingleTHPairCAS("Freiheit und Leben kann man uns nehmen, die Ehre nicht", "Otto Wels hat das gesagt."); 
-
-			// probeCas check whether or not the CAS has all needed "Entailment" information. 
-			// If it does not, it raises an LAPException. 
-			// It will also print the summarized data of the CAS to the PrintStream. 
-			// If the second argument is null, it will only check the format and raise Exceptions, without printing 
-			PlatformCASProber.probeCas(aJCas, System.out); // it has dependency annotations. 
-			
-			// To see the full content of each View, use this 
-			//PlatformCASProber.probeCasAndPrintContent(aJCas, System.out); 
-//			aJCas.reset(); 
-//			JCas aJCas2 = lap.generateSingleTHPairCAS("Heute ist Freitag.", "Heute ist nicht Montag."); 
-//			PlatformCASProber.probeCas(aJCas2, System.out); 
+//FROZEN
+//WE will revive MSTParser after DKPRO 1.5.0 gets stable and uploaded to Maven Central 
+//
+//import static org.junit.Assert.*;
+//
+//import org.apache.uima.jcas.JCas;
+//import org.junit.Test;
+//
+//import eu.excitementproject.eop.lap.LAPAccess;
+//import eu.excitementproject.eop.lap.LAPException;
+//import eu.excitementproject.eop.lap.PlatformCASProber;
+//
+//public class MSTParserDETest {
+//
+//	@Test
+//	public void test() {
+//		// Generating a Single CAS 
+//		LAPAccess lap = null; 
+//		JCas aJCas = null; 
+//
+//		try {
+//			lap = new MSTParserDE(); // same as ("default"); 
+//			//lap = new MSTParserDE("long"); 
 //			
-			// Note that: the above code --- 
-			// Model loading was only done twice (once for TView, once for HView), and not duplicated 
-			// after the first call. 
-
-		}
-		catch(LAPException e)
-		{
-			fail(e.getMessage()); 
-		}
-		
-		// TODO: loading larger model test. (different variant) 
-		
-	}
-
-}
+//			// one of the LAPAccess interface: that generates single TH CAS. 
+//			aJCas = lap.generateSingleTHPairCAS("Freiheit und Leben kann man uns nehmen, die Ehre nicht", "Otto Wels hat das gesagt."); 
+//
+//			// probeCas check whether or not the CAS has all needed "Entailment" information. 
+//			// If it does not, it raises an LAPException. 
+//			// It will also print the summarized data of the CAS to the PrintStream. 
+//			// If the second argument is null, it will only check the format and raise Exceptions, without printing 
+//			PlatformCASProber.probeCas(aJCas, System.out); // it has dependency annotations. 
+//			
+//			// To see the full content of each View, use this 
+//			//PlatformCASProber.probeCasAndPrintContent(aJCas, System.out); 
+////			aJCas.reset(); 
+////			JCas aJCas2 = lap.generateSingleTHPairCAS("Heute ist Freitag.", "Heute ist nicht Montag."); 
+////			PlatformCASProber.probeCas(aJCas2, System.out); 
+////			
+//			// Note that: the above code --- 
+//			// Model loading was only done twice (once for TView, once for HView), and not duplicated 
+//			// after the first call. 
+//
+//		}
+//		catch(LAPException e)
+//		{
+//			fail(e.getMessage()); 
+//		}
+//		
+//		// TODO: loading larger model test. (different variant) 
+//		
+//	}
+//
+//}


### PR DESCRIPTION
MSTParser relied on SNAPSHOT artifacts. removing them (MSTParser will be re-introduced once related codes become stable) 
- commented all MST parser and related code from LAP. They will be revived only when MSTParser DKPro component becomes stable.
