### PR TITLE
Debugging in GermaNetWrapper: Temporary solution for treatment of antonymy

### DIFF
--- a/core/src/test/java/eu/excitementproject/eop/core/GermaNetAntonymyTest.java
+++ b/core/src/test/java/eu/excitementproject/eop/core/GermaNetAntonymyTest.java
@@ -1,0 +1,328 @@
+
+package eu.excitementproject.eop.core;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalResourceException;
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalRule;
+import eu.excitementproject.eop.common.exception.BaseException;
+import eu.excitementproject.eop.core.component.lexicalknowledge.germanet.GermaNetInfo;
+import eu.excitementproject.eop.core.component.lexicalknowledge.germanet.GermaNetNotInstalledException;
+import eu.excitementproject.eop.core.component.lexicalknowledge.germanet.GermaNetRelation;
+import eu.excitementproject.eop.core.component.lexicalknowledge.germanet.GermaNetWrapper;
+import eu.excitementproject.eop.common.representation.partofspeech.GermanPartOfSpeech;
+import eu.excitementproject.eop.common.representation.partofspeech.UnsupportedPosTagStringException;;
+
+
+
+/**
+ * @author Britta Zeller 
+ *
+ */
+public class GermaNetAntonymyTest {
+
+	@Test
+	public void test() throws UnsupportedPosTagStringException {
+		
+		//System.out.println("################### for direct path-only call");
+		// Confidence values are automatically set in the GermaNetWrapper constructor: 
+		// all DEFAULT_CONF, except antonymy (0.0)  
+		GermaNetWrapper gnw=null;
+		try {
+			gnw = new GermaNetWrapper("/mnt/resources/ontologies/germanet-7.0/GN_V70/GN_V70_XML/");			
+		}
+		catch (GermaNetNotInstalledException e) {
+			//System.out.println("WARNING: GermaNet files are not found in the given path. Please correctly install and pass the path to GermaNetWrapper");
+			//throw e;
+		}
+		catch(BaseException e)
+		{
+			e.printStackTrace(); 
+		}
+		Assume.assumeNotNull(gnw); // if gnw is null, the following tests will not be run. 
+
+		
+		//System.out.println("################################################################################");
+		
+		//System.out.println("****************************************************");
+		//System.out.println("WITHOUT FINE-GRAINED RELATIONS");
+		//System.out.println("****************************************************");
+		
+		// ******************************************************************************
+		// NO FINE-GRAINED RELATIONS
+		// ******************************************************************************
+		
+		// Test for relations without fine grained relation -- thus without antonymy.
+		// test via getRulesForLeft
+		try{
+			//System.out.println("*** without fine grained relation, getRulesForLeft");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForLeft("Kauf", new GermanPartOfSpeech("NN"));
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(!rule.getRLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}	
+		
+		
+		// Test for relations without fine grained relation -- thus without antonymy.
+		// test via getRulesForRight
+		try{
+			//System.out.println("*** without fine grained relation, getRulesForRight");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForRight("Kauf", new GermanPartOfSpeech("NN"));
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getRLemma().equals("Kauf"));
+				assertTrue(!rule.getLLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}			
+		
+
+		// Test for relations without fine grained relation -- thus without antonymy.
+		// test via getRules
+		try{
+			//System.out.println("*** without fine grained relation, getRules for antonym pair");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRules("Kauf", new GermanPartOfSpeech("NN"), "Verkauf", new GermanPartOfSpeech("NN"));
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(!rule.getRLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}
+
+		
+		// Test for relations without fine grained relation -- thus without antonymy.
+		// test via getRules, this time for a valid (positively related) pair
+		try{
+			//System.out.println("*** without fine grained relation, getRules for synonym pair");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRules("Kauf", new GermanPartOfSpeech("N"), "Ankauf", new GermanPartOfSpeech("NN"));
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(!rule.getRLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}		
+
+		
+		// ******************************************************************************
+		// FINE-GRAINED RELATIONS
+		//System.out.println("****************************************************");
+		//System.out.println("WITH FINE-GRAINED RELATIONS");
+		//System.out.println("****************************************************");
+		// ******************************************************************************
+		
+		// Test for relations with fine grained relation "antonymy".
+		// test via getRulesForLeft
+		try{
+			//System.out.println("*** with fine grained relation 'antonymy', getRulesForLeft");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForLeft("Kauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_antonym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(rule.getRLemma().equals("Verkauf"));
+				assertTrue(rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() == 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}	
+
+		// Test for relations with fine grained relation "synonymy".
+		// test via getRulesForLeft
+		try{
+			//System.out.println("*** with fine grained relation 'synonymy', getRulesForLeft");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForLeft("Kauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_synonym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(!rule.getRLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}		
+		
+		// Test for relations with fine grained relation "antonymy".
+		// test via getRulesForRight
+		try{
+			//System.out.println("*** with fine grained relation 'antonymy', getRulesForRight");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForRight("Kauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_antonym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getRLemma().equals("Kauf"));
+				assertTrue(rule.getLLemma().equals("Verkauf"));
+				assertTrue(rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() == 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}			
+
+
+		// Test for relations with fine grained relation "synonymy".
+		// test via getRulesForRight
+		try{
+			//System.out.println("*** with fine grained relation 'synonymy', getRulesForRight");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForRight("Kauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_synonym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getRLemma().equals("Kauf"));
+				assertTrue(!rule.getLLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getRelation().equals("has_synonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}			
+		
+
+		// Test for relations with fine grained relation "hypernymy".
+		// test via getRulesForRight -- should result in empty result list
+		try{
+			//System.out.println("*** with fine grained relation 'hypernymy', getRulesForRight");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForRight("Kauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_hypernym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getRLemma().equals("Kauf"));
+				assertTrue(!rule.getLLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}	
+		
+
+		// Test for relations with fine grained relation "hyponymy".
+		// test via getRulesForRight -- should result in empty result list
+		try{
+			//System.out.println("*** with fine grained relation 'hyponymy', getRulesForRight");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForRight("Kauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_hyponym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getRLemma().equals("Kauf"));
+				assertTrue(!rule.getLLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getRelation().equals("has_hyponym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}			
+		
+		// Test for relations with fine grained relation "antonymy".
+		// test via getRules, with an antonymic pair, thus resulting in an 1-entry list
+		try{
+			//System.out.println("*** with fine grained relation 'antonymy', getRules for antonym pair");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRules("Kauf", new GermanPartOfSpeech("NN"), "Verkauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_antonym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(rule.getRLemma().equals("Verkauf"));
+				assertTrue(rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() == 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}
+
+		
+		// Test for relations with fine grained relation "antonymy".
+		// test via getRules, this time for a valid (positively related) pair, thus resulting in an empty list
+		try{
+			//System.out.println("*** with fine grained relation 'antonymy', getRules for synonym pair");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRules("Kauf", new GermanPartOfSpeech("N"), "Ankauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_antonym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(!rule.getRLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}		
+
+				
+		// Test for relations with fine grained relation "synonymy".
+		// test via getRules, this time for a valid (positively related) pair
+		try{
+			//System.out.println("*** with fine grained relation 'synonymy', getRules for synonym pair");
+			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRules("Kauf", new GermanPartOfSpeech("N"), "Ankauf", new GermanPartOfSpeech("NN"), GermaNetRelation.has_synonym);
+			//System.out.println("resulting rules (size: " +rules.size() + "): ");
+			for (LexicalRule<? extends GermaNetInfo> rule : rules) {
+				//System.out.println(rule.toString());
+				assertTrue(rule.getLLemma().equals("Kauf"));
+				assertTrue(!rule.getRLemma().equals("Verkauf"));
+				assertTrue(!rule.getRelation().equals("has_antonym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}		
+	
+	}
+}
+

--- a/core/src/test/java/eu/excitementproject/eop/core/GermaNetWrapperTest.java
+++ b/core/src/test/java/eu/excitementproject/eop/core/GermaNetWrapperTest.java
@@ -22,7 +22,23 @@ import eu.excitementproject.eop.common.representation.partofspeech.UnsupportedPo
 
 
 /**
- * @author Jan Pawellek 
+ * Test class to check if GermaNetWrapper works correctly with all three 
+ * different initialization possibilities and with all different callable 
+ * methods.
+ * 
+ * The first part of the tests loads GermaNetWrapper by only handing the 
+ * GermaNet installation path to its constructor.
+ * The second part loads GermaNetWrapper via a CommonConfig configuration file.
+ * The third part loads GermaNetWrapper by handing the GermaNet installation
+ * path and confidence values to GermaNetWrapper's constructor.
+ *  
+ * All callable methods are tested:
+ * getRulesForLeft(lemma, pos), getRulesForLeft(lemma, pos, ownRelation)
+ * getRulesForRight(lemma, pos), getRulesForRight(lemma, pos, ownRelation)
+ * getRules(lemma, pos, lemma, pos), getRules(lemma, pos, lemma, pos, ownRelation)
+ * 
+ * 
+ * @author Jan Pawellek, Britta Zeller, Julia Kreutzer 
  *
  */
 public class GermaNetWrapperTest {
@@ -32,8 +48,10 @@ public class GermaNetWrapperTest {
 		
 		GermaNetWrapper gnw=null;
 
-		
+	
 		try {
+
+			System.out.println("### run 1: path");
 			gnw = new GermaNetWrapper("/mnt/resources/ontologies/germanet-7.0/GN_V70/GN_V70_XML/");
 			
 			/* for GermaNet Evaluation -> test GermaNet for outputs for specific words, saved in testwords
@@ -72,10 +90,13 @@ public class GermaNetWrapperTest {
 		}
 		Assume.assumeNotNull(gnw); // if gnw is null, the following tests will not be run. 
 
+
+
 		// Test for "simplest" generic method 
 		List<LexicalRule<? extends GermaNetInfo>> list1 = null; 
 		try {
-			list1 = gnw.getRulesForLeft("wachsen", null); 
+			//System.out.println("** 1");
+			list1 = gnw.getRulesForLeft("wachsen", null);
 			assertTrue(list1.size() > 0); 
 		}
 		catch (LexicalResourceException e)
@@ -85,24 +106,28 @@ public class GermaNetWrapperTest {
 		
 		// Test for verbs
 		try{
+
+			//System.out.println("** 2");
 			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForLeft("wachsen", new GermanPartOfSpeech("VINF"), GermaNetRelation.has_antonym)) {
 				assertTrue(rule.getLLemma().equals("wachsen"));
+				//System.out.println("for wachsen: " + rule.getRLemma());
 				assertTrue(rule.getInfo().getLeftSynsetID() == 59751 || rule.getInfo().getLeftSynsetID() == 54357); // might only be true in GermaNet 7.0
 				assertTrue(rule.getRLemma().equals("schrumpfen"));
 				assertTrue(rule.getInfo().getRightSynsetID() == 59780 || rule.getInfo().getRightSynsetID() == 54511); // might only be true in GermaNet 7.0
 				assertTrue(rule.getRelation().equals("has_antonym"));
-				assertTrue(rule.getConfidence() > 0);
+				assertTrue(rule.getConfidence() == 0);
 			}
 		}
 		catch (LexicalResourceException e)
 		{
 			e.printStackTrace(); 
-		}		
+		}	
 		
 		
 		// Negative test for verbs to show the given POS is used
 		try{
-			List<LexicalRule<? extends GermaNetInfo>> rule = gnw.getRulesForLeft("wachsen", new GermanPartOfSpeech("NN"), GermaNetRelation.has_antonym);
+			//System.out.println("** 3");
+			List<LexicalRule<? extends GermaNetInfo>> rule = gnw.getRulesForLeft("wachsen", new GermanPartOfSpeech("NN"), GermaNetRelation.has_synonym);
 			assertTrue(rule.isEmpty());
 		}
 		catch (LexicalResourceException e)
@@ -112,6 +137,7 @@ public class GermaNetWrapperTest {
 		
 		// Test for level-maximum for verbs, granted that "lernen" has 4 rules on the first level (might only be true in GermaNet 7.0)
 		try{
+			//System.out.println("** 4");
 			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForLeft("lernen", new GermanPartOfSpeech("VINF"));
 			assertTrue(rules.size()==4);
 			for (LexicalRule<? extends GermaNetInfo> rule : rules){
@@ -126,12 +152,15 @@ public class GermaNetWrapperTest {
 		}
 		
 		// Test for common nouns
+
 		try{
+			//System.out.println("** 5");
 			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForLeft("Hitze", new GermanPartOfSpeech("NN"), GermaNetRelation.has_antonym)) {
+				//System.out.println("lLemma: " + rule.getLLemma() + ", rLemma: " + rule.getRLemma());
 				assertTrue(rule.getLLemma().equals("Hitze"));
 				assertTrue(rule.getRLemma().equals("Kälte"));
 				assertTrue(rule.getRelation().equals("has_antonym"));
-				assertTrue(rule.getConfidence() > 0);
+				assertTrue(rule.getConfidence() == 0);
 			}
 		}
 		catch (LexicalResourceException e)
@@ -141,6 +170,7 @@ public class GermaNetWrapperTest {
 		
 		// Test of not-supported POS type (should return an empty list) 
 		try {
+			//System.out.println("** 6");
 			List<LexicalRule<? extends GermaNetInfo>> l = gnw.getRulesForLeft("Hitze", new GermanPartOfSpeech("PTKA")); 
 			assertTrue(l.size() == 0); 
 			// Still, null POS should mean, don't care
@@ -155,9 +185,11 @@ public class GermaNetWrapperTest {
 		
 		// Test for level-maximum for nouns, granted that "Katze" has 7 rules on the first two levels (might only be true in GermaNet 7.0)
 		try{
+			//System.out.println("** 7");
 			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForLeft("Katze", new GermanPartOfSpeech("NN"));
 			assertTrue(rules.size()==9);
 			for (LexicalRule<? extends GermaNetInfo> rule : rules){
+				//System.out.println("lLemma: " + rule.getLLemma() + ", rLemma: " + rule.getRLemma());
 				assertFalse(rule.getRLemma()=="Katze");
 				assertFalse(rule.getRLemma()=="Bestie");
 				assertFalse(rule.getRLemma()=="GN_ROOT");
@@ -170,9 +202,11 @@ public class GermaNetWrapperTest {
 		
 		// Test for level-maximum for adjectives, granted that "klein" has 1 rule on the first level (might only be true in GermaNet 7.0)
 		try{
+			//System.out.println("** 8");
 			List<LexicalRule<? extends GermaNetInfo>> rules = gnw.getRulesForLeft("klein", new GermanPartOfSpeech("ADJ"));
 			assertTrue(rules.size()==1);
 			for (LexicalRule<? extends GermaNetInfo> rule : rules){
+				//System.out.println("lLemma: " + rule.getLLemma() + ", rLemma: " + rule.getRLemma());
 				assertFalse(rule.getRLemma()=="klein");
 				assertFalse(rule.getRLemma()=="klassenübergreifend");
 				assertFalse(rule.getRLemma()=="GN_ROOT");
@@ -184,7 +218,10 @@ public class GermaNetWrapperTest {
 		}
 
 		
-		// Test for CommonConfig passing 
+		
+		// Test for CommonConfig passing
+		//System.out.println("### run 2: common config");
+		
 		gnw=null;
 		try {
 			File f = new File("./src/test/resources/german_resource_test_configuration.xml");
@@ -202,11 +239,13 @@ public class GermaNetWrapperTest {
 
 		// repeat the test for common nouns, with CommonConfig inited gnw
 		try{
+			//System.out.println("** 9");
 			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForLeft("Hitze", new GermanPartOfSpeech("NN"), GermaNetRelation.has_antonym)) {
+				//System.out.println("lLemma: " + rule.getLLemma() + ", rLemma: " + rule.getRLemma());
 				assertTrue(rule.getLLemma().equals("Hitze"));
 				assertTrue(rule.getRLemma().equals("Kälte"));
 				assertTrue(rule.getRelation().equals("has_antonym"));
-				assertTrue(rule.getConfidence() > 0);
+				assertTrue(rule.getConfidence() == 0);
 			}
 		}
 		catch (LexicalResourceException e)
@@ -214,12 +253,29 @@ public class GermaNetWrapperTest {
 			e.printStackTrace(); 
 		}
 		
+		// check for hypernyms only
+		try{
+			//System.out.println("** 9a");
+			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForLeft("Hitze", new GermanPartOfSpeech("NN"), GermaNetRelation.has_hypernym)) {
+				//System.out.println("lLemma: " + rule.getLLemma() + ", rLemma: " + rule.getRLemma());
+				assertTrue(rule.getLLemma().equals("Hitze"));
+				assertTrue(rule.getRLemma().equals("Wärmegrad") || rule.getRLemma().equals("Wert") || rule.getRLemma().equals("Temperatur") );
+				assertTrue(rule.getRelation().equals("has_hypernym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}		
+		
 		// repeat test for "simplest" generic method, with CommonConfig initiated gnw. 
 		// and compares the result to previous one.  
 		List<LexicalRule<? extends GermaNetInfo>> list2 = null; 
 		try {
+			//System.out.println("** 10");
 			list2 = gnw.getRulesForLeft("wachsen", null); 
-			assertTrue(list2.size() > 0); 
+			assertTrue(list2.size() > 0);
 		}
 		catch (LexicalResourceException e)
 		{
@@ -237,7 +293,9 @@ public class GermaNetWrapperTest {
 		
 		// checking that no antonym in getRulesForLeft() 
 		try{
+			//System.out.println("** 11");
 			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForLeft("Hitze", null)) {
+				//System.out.println("lLemma: " + rule.getLLemma() + ", rLemma: " + rule.getRLemma());
 				assertTrue(rule.getLLemma().equals("Hitze"));
 				assertFalse(rule.getRLemma().equals("Kälte")); // no "Kaelte" should be here.  
 				assertTrue(rule.getConfidence() > 0);
@@ -247,10 +305,13 @@ public class GermaNetWrapperTest {
 		{
 			e.printStackTrace(); 
 		}
-				
+			
+
+		
 		// check that no 0 confidence value returns 
-		try {// Initiating with "no hypernym" (0 confidence on hypernym)  
-			gnw = new GermaNetWrapper("/mnt/resources/ontologies/germanet-7.0/GN_V70/GN_V70_XML/", 1.0, 1.0, 0.0, 1.0, 1.0);
+		//System.out.println("### run 3: check man. set confidence values");
+		try {// Initiating with "no synonym and antonym" (0 confidence on synonym and per internal definition antonym)
+			gnw = new GermaNetWrapper("/mnt/resources/ontologies/germanet-7.0/GN_V70/GN_V70_XML/", 1.0, 1.0, 1.0, 0.0, 1.0); // , 0.0
 		}
 		catch (GermaNetNotInstalledException e) {
 			System.out.println("WARNING: GermaNet files are not found in the given path. Please correctly install and pass the path to GermaNetWrapper");
@@ -261,11 +322,13 @@ public class GermaNetWrapperTest {
 			e.printStackTrace(); 
 		}
 
-		// there should be no hypernym RHS, neither anyone with 0 confidence. 
+		// there should be no synonym RHS, neither anyone with 0 confidence. 
 		try{
+			//System.out.println("** 12");
 			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForLeft("Hund", null)) {
+				//System.out.println("lLemma: " + rule.getLLemma() + ", rLemma: " + rule.getRLemma());
 				assertTrue(rule.getConfidence() > 0);
-				assertFalse(rule.getRelation().equals("has_hypernym")); 
+				assertFalse(rule.getRelation().equals("has_synonym")); 
 			}
 		}
 		catch (LexicalResourceException e)
@@ -273,11 +336,13 @@ public class GermaNetWrapperTest {
 			e.printStackTrace(); 
 		}
 		
-		//test for getRulesForRight, only hyponyms and synonyms allowed
+		//test for getRulesForRight, only hyponyms and synonyms allowed per definition
 		try{
+			//System.out.println("** 13");
 			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForRight("Hund", new GermanPartOfSpeech("NN"))) {
-				assertTrue(rule.getLLemma().equals("Hund"));
-				assertTrue(!rule.getRLemma().equals("Hund"));
+				//System.out.println(rule.getLLemma() + ", " + rule.getRLemma());
+				assertTrue(rule.getRLemma().equals("Hund"));
+				assertTrue(!rule.getLLemma().equals("Hund"));
 				assertTrue(rule.getInfo().getLeftSynsetID() == 50708); // might only be true in GermaNet 7.0
 				assertTrue((rule.getRelation().equals("has_hyponym")) || (rule.getRelation().equals("has_synonym")));
 				assertTrue(rule.getConfidence() > 0);
@@ -286,7 +351,78 @@ public class GermaNetWrapperTest {
 		catch (LexicalResourceException e)
 		{
 			e.printStackTrace(); 
+		}
+
+
+		//test for getRulesForRight, only hyponyms wanted
+		try{
+			//System.out.println("** 14");
+			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRulesForRight("Hund", new GermanPartOfSpeech("NN"), GermaNetRelation.has_hyponym)) {
+				//System.out.println(rule.getLLemma() + ", " + rule.getRLemma());
+				assertTrue(rule.getRLemma().equals("Hund"));
+				assertTrue(!rule.getLLemma().equals("Hund"));
+				assertTrue(rule.getInfo().getLeftSynsetID() == 50708); // might only be true in GermaNet 7.0
+				assertTrue(rule.getRelation().equals("has_hyponym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}
+		
+
+		//test for getRules with hyponyms (but no relation restriction in the call); 
+		// should return 1 rule
+		try{
+			//System.out.println("** 15");
+			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRules("Pudel", new GermanPartOfSpeech("NN"), "Hund", new GermanPartOfSpeech("NN"))) {
+				//System.out.println(rule.getLLemma() + ", " + rule.getRLemma());
+				assertTrue(rule.getRLemma().equals("Hund"));
+				assertTrue(rule.getLLemma().equals("Pudel"));
+				assertTrue(!rule.getLLemma().equals("Hund"));
+				assertTrue(rule.getInfo().getRightSynsetID() == 50708); // might only be true in GermaNet 7.0
+				assertTrue((rule.getRelation().equals("has_hypernym")));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
 		}		
+		
+		//"false" test for getRules with hyponyms (but no relation restriction in the call); 
+		// should return empty list
+		try{
+			//System.out.println("** 15a");
+			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRules("Hund", new GermanPartOfSpeech("NN"), "Pudel", new GermanPartOfSpeech("NN"))) {
+				System.err.println("this text for rule " + rule.toString() 
+						+ " in GermaNet lookup should not occur; it means an error in the logic");
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}		
+				
+		
+		//test for getRules, only hypernyms allowed
+		try{
+			//System.out.println("** 16");
+			for (LexicalRule<? extends GermaNetInfo> rule : gnw.getRules("Pudel", new GermanPartOfSpeech("NN"), "Hund", new GermanPartOfSpeech("NN"), GermaNetRelation.has_hypernym)) {
+				//System.out.println(rule.getLLemma() + ", " + rule.getRLemma());
+				assertTrue(rule.getLLemma().equals("Pudel"));
+				assertTrue(rule.getRLemma().equals("Hund"));
+				assertTrue(rule.getRelation().equals("has_hypernym"));
+				assertTrue(rule.getConfidence() > 0);
+			}
+		}
+		catch (LexicalResourceException e)
+		{
+			e.printStackTrace(); 
+		}		
+			
+		
 	}
 }
 

--- a/core/src/test/resources/german_resource_test_configuration.xml
+++ b/core/src/test/resources/german_resource_test_configuration.xml
@@ -6,24 +6,31 @@
 
 <configuration>
 
-
 	<section name="GermaNetWrapper">
-		<!-- GermaNetWrapper options: path to GermanNet top dir, and relations to be used for LHS->RHS 
-	    	 or RHS->LHS, as a value of confidence [0.0 - 1.0] --> 
+		<!-- GermaNetWrapper options: path to GermanNet top directory, and relations to be 
+		     used for LHS->RHS or RHS->LHS, as a value of confidence [0.0 - 1.0] --> 
 
-		<!-- you need to update this for your own GermaNet path. If not found, GermaNet init will raise an exception. -->
+		<!-- you need to update this for your own GermaNet path. If not found, 
+		     GermaNet init will raise an exception. -->
 		<property name="germaNetFilesPath">/mnt/resources/ontologies/germanet-7.0/GN_V70/GN_V70_XML/</property>  
 
-		<!-- GermaNet relations and their confidences (LHS -> RHS) --> 
+		<!-- GermaNet relations and their confidences. 
+		     Confidence of 1.0 means "this relation absolutely means Entailment".
+		     Confidence of 0.0 means "this relation absolutely means Non-Entailment".
+		     Confidence of 0.5 means "I can't say anything about Entailment decision".
+			 DEFAULT values: 0.5 for all positive relations. -->
+		<!-- LHS -> RHS relations --> 
 		<property name="causesConfidence">0.5</property> 
 		<property name="entailsConfidence">0.5</property>
-		<property name="hypernymConfidence">0.5</property> 
-		<property name="synonymConfidence">0.5</property>
+		<property name="hypernymConfidence">0.5</property>
 		
-		<!-- GermaNet relations and their confidences (RHS -> LHS) -->
-		<property name="antonymConfidence">0.5</property> 
+		<!-- both LHS -> RHS and RHS -> LHS relations --> 
+		<property name="synonymConfidence">0.5</property> 
+		
+		<!-- RHS -> LHS relations -->
 		<property name="hyponymConfidence">0.5</property>
 	</section> 
+	
 	
 	
 	<!-- Specifies parameters for the derivational resource DErivBase (similar to CatVar for English). -->


### PR DESCRIPTION
- Antonymy it is basically retrieved for all getRules\* calls, but only
  returned for getRules*withOwnRelation calls
- Antonymy's confidence score is hard-coded to 0.0.
- At the moment, the decision if a lexical rule (entailment and non-
  entailment) is returned depends on the confidence score: 0.0 scores
  are not returned, except for withOwnRelation calls
- Added JUnit Test GermaNetAntonymyTest to test antonymy

Smaller bugs in GermaNetWraooer:
- mapping of N and NN to equivalence was not treated so far
- corrected order of lemma/pos pairs for getRulesForRight() calls
