### PR TITLE
- patched RTE+ XML file reader. Previously, "task" on each pair was mand...

### DIFF
--- a/lap/src/main/java/eu/excitementproject/eop/lap/lappoc/RawDataFormatReader.java
+++ b/lap/src/main/java/eu/excitementproject/eop/lap/lappoc/RawDataFormatReader.java
@@ -110,9 +110,10 @@ public class RawDataFormatReader {
 		String goldAnswer = pair.getAttribute("entailment"); 
 		String task = pair.getAttribute("task"); 
 		
-		// throw exception if missing task or id 
-		if (task.length() == 0 || id.length() == 0)
-			throw new RawFormatReaderException("A pair with missing task or id"); 
+		// throw exception if missing pair id 
+		//if (task.length() == 0 || id.length() == 0) // note that task can actually be empty. 
+		if (id.length() ==0)
+			throw new RawFormatReaderException("A pair with missing pair id. Wrong format."); 
 		
 		// generate return data structure and return it 
 		PairXMLData pairData = new PairXMLData(text, hypothesis, id, goldAnswer, task); 

--- a/lap/src/test/resources/small.xml
+++ b/lap/src/test/resources/small.xml
@@ -4,7 +4,7 @@
 		<t>Claude Chabrol (born June 24, 1930) is a French movie director and has become well-known in the 40 years since his first film, Le Beau Serge , for his chilling tales of murder, including Le Boucher .</t>
 		<h>Le Beau Serge was directed by Chabrol.</h>
 	</pair>
-	<pair id="2" task="IE" >
+	<pair id="2"> <!--  intentionally has no task  -->
 		<t>Claude Chabrol (born June 24, 1930) is a French movie director and has become well-known in the 40 years since his first film, Le Beau Serge , for his chilling tales of murder, including Le Boucher .</t>
 		<h>Le Boucher was made by a French movie director.</h>
 	</pair>


### PR DESCRIPTION
...atory, and the reader wouldn't process without it. Spec got updated, and task is now an option. Reflected this, with testfile update, and works okay.
