### PR TITLE
EmbeddedRedisBased LexicalResource

### DIFF
--- a/distsim/pom.xml
+++ b/distsim/pom.xml
@@ -33,6 +33,12 @@
 	<artifactId>hadoop-core</artifactId>
 	<version>0.20.2</version>
    </dependency>
+   
+   <dependency>
+	<groupId> com.google.guava</groupId>
+	<artifactId>guava</artifactId>
+	<version>15.0</version>
+   </dependency>
      
     <dependency>
 		<groupId>eu.excitementproject</groupId>
@@ -64,5 +70,20 @@
 		<version>1.1</version>
 	</dependency>-->
  
+  	<dependency>
+  		<groupId>de.uni-heidelberg.cl</groupId>
+  		<artifactId>embedded-redis</artifactId>
+  		<version>20131205</version>
+  	</dependency>
+
+    <!-- uncomment the following to include the German redis rdb file for test-->
+	<!--     
+	<dependency>
+  		<groupId>de.uni-heidelberg.cl</groupId>
+  		<artifactId>redis-german-lin-prox</artifactId>
+  		<version>0.1</version>
+  	</dependency>
+  	 --> 
+ 	
   	</dependencies>
 </project>

--- a/distsim/src/main/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisBasedLexicalResource.java
+++ b/distsim/src/main/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisBasedLexicalResource.java
@@ -1,0 +1,201 @@
+package eu.excitementproject.eop.distsim.redisinjar;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+
+import com.google.common.io.Files;
+
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalResource;
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalResourceCloseException;
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalResourceException;
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalRule;
+import eu.excitementproject.eop.common.component.lexicalknowledge.RuleInfo;
+import eu.excitementproject.eop.common.representation.partofspeech.PartOfSpeech;
+import eu.excitementproject.eop.distsim.resource.SimilarityStorageBasedLexicalResource;
+import eu.excitementproject.eop.distsim.storage.DefaultSimilarityStorage;
+import eu.excitementproject.eop.distsim.storage.RedisBasedStringListBasicMap;
+import eu.excitementproject.eop.distsim.storage.SimilarityStorage;
+
+/**
+ * This is a lexical-resource implementation that utilizes Redis-In-Jar RedisServerRunner 
+ * code. Basically, the resource operates in two modes. 
+ *
+ * a) redis-server is running on external: the resource will get two server names and port 
+ * and utilizes those. 
+ * b) redis-server is not running yet, and the resource boot himself up: in this case, the 
+ * implementation gets redis-model file resourcePath (classpath); and the resource gets the 
+ * model (rdb file) from Jar, run redis server from redis-server Jar (by using RedisServerRunner)
+ * and start redis server locally (127.0.0.1), and uses that server.  
+ * 
+ * NOTE: this resource requires close() call, always. 
+ * 
+ * 
+ * TODO: port checking --- if port is open, don't even start, etc.  
+ * 
+ * @author Tae-Gil Noh
+ *
+ */
+public class EmbeddedRedisBasedLexicalResource implements LexicalResource<RuleInfo> {
+	
+	/**
+	 * 
+	 * This constructor is for those cases where the redis server is already up and 
+	 * running somewhere. The resource simply taps to that server/port and offer 
+	 * LexicalResource. 
+	 * 
+	 * @param l2rServer Name (or IP) of the server to connect, L->R sim redis server  
+	 * @param l2rPort port number of the server to connect, L->R sim redis server 
+	 * @param r2lServer Name (or IP) of the server to connect, R->L sim redis server 
+	 * @param r2lPort port number of the server to connect, R->L sim redis server 
+	 * @param maxNumOfRetrievedRules Maximum number of rules that will be returned. They are ordered. If null, return all. 
+	 */
+	public EmbeddedRedisBasedLexicalResource(String l2rServer, int l2rPort, String r2lServer, int r2lPort, int maxNumOfRetrievedRules)
+	{
+		// set logger 
+        logger = Logger.getLogger(this.getClass().getName()); 
+		
+		RedisBasedStringListBasicMap l2rMap = new RedisBasedStringListBasicMap(l2rServer, l2rPort);
+		RedisBasedStringListBasicMap r2lMap = new RedisBasedStringListBasicMap(r2lServer, r2lPort); 
+		SimilarityStorage theStorage = new DefaultSimilarityStorage(l2rMap, r2lMap, "CompName", "InstName", "eu.excitementproject.eop.distsim.items.LemmaPosBasedElement");
+		// note that Component Name and Instance Name will be overridden by 
+		// the LexicalResource that extends this abstract class. so we don't care about them and 
+		// set simply as "CompName" and "InstName". Those won't be visible to end users. 
+
+		// actual worker 
+		theLexicalResource = new SimilarityStorageBasedLexicalResource(theStorage, maxNumOfRetrievedRules);
+	}
+
+	/**
+	 * 
+	 * This constructor is for the cases where there is no running redis server for the 
+	 * requested file (resource). 
+	 * 
+	 * The method gets two URL of the RDB files in the JAR (e.g. Classloader.getResource(classPathOfTheFileInJar)). 
+	 * And it runs Redis-Server, by running binaries provided by embedded-redis artifact. 
+	 * It runs the server on the local host, but it requires the user to provide the port number.  
+	 *  
+	 * Note: Extracting and Loading Redis models on redis-server takes some time; depending on the 
+	 * redis RDB file size. 
+	 * 
+	 * @param l2rResource URL of the resource (e.g. Classloader.getResource()) that holds redis rdb file in Jar, L->R similarity   
+	 * @param r2lResource URL of the resource (e.g. Classloader.getResource()) that holds redis rdb file in Jar, R->L similarity
+	 * @param l2rPort port number in string; to be opened on local host for redis-server L->R sim 
+	 * @param r2lPort port number in string; to be opened on local host for redis-server R->L sim 
+	 * @param maxNumOfRetrievedRules Maximum number of rules that will be returned. They are ordered. If null, return all.
+	 */
+	public EmbeddedRedisBasedLexicalResource(URL l2rResource, URL r2lResource, int l2rPort, int r2lPort, int maxNumOfRetrievedRules) throws LexicalResourceException
+	{
+
+		// set logger 
+        logger = Logger.getLogger(this.getClass().getName()); 
+
+		try {
+			logger.info("extracting l2r redis db file");
+			File l2rRdb = extractDataFileFromResource(l2rResource); 
+			logger.info("extracted in: " + l2rRdb.getParent() + "//" + l2rRdb.getName()); 
+			
+			logger.info("extracting r2l redis db file");
+			File r2lRdb = extractDataFileFromResource(r2lResource); 
+			logger.info("extracted in: " + r2lRdb.getParent() + "//" + r2lRdb.getName()); 
+			
+			rs_l = new EmbeddedRedisServerRunner(l2rPort, l2rRdb.getParent(), l2rRdb.getName()); 
+			rs_r = new EmbeddedRedisServerRunner(r2lPort, r2lRdb.getParent(), r2lRdb.getName()); 
+			
+			// run the redis server ... 
+			rs_l.start();
+			//Thread.sleep(1000); // do we need this? no. 
+			rs_r.start(); 
+			//Thread.sleep(5000); 
+		} catch (IOException e)
+		{
+			throw new LexicalResourceException("Failed to run Redis-Embedded Server!" + e.getMessage()); 
+		}
+		
+		if ( (rs_l == null) || (rs_r == null) )
+		{
+			throw new LexicalResourceException("Failed to run Redis-Embedded Server! - RedisServerRunner returned null (integrity failure, you shouldn't see this exception)"); 			
+		}
+		
+		// Okay. now redis servers are up and running on local. 
+
+		RedisBasedStringListBasicMap l2rMap = new RedisBasedStringListBasicMap("127.0.0.1", l2rPort);
+		RedisBasedStringListBasicMap r2lMap = new RedisBasedStringListBasicMap("127.0.0.1", r2lPort); 
+		SimilarityStorage theStorage = new DefaultSimilarityStorage(l2rMap, r2lMap, "CompName", "InstName", "eu.excitementproject.eop.distsim.items.LemmaPosBasedElement");
+		// note that Component Name and Instance Name will be overridden by 
+		// the LexicalResource that extends this abstract class. so we don't care about them and 
+		// set simply as "CompName" and "InstName". Those won't be visible to end users. 
+
+		// actual worker 
+		theLexicalResource = new SimilarityStorageBasedLexicalResource(theStorage, maxNumOfRetrievedRules);
+	}
+	
+	@Override
+	public List<LexicalRule<? extends RuleInfo>> getRulesForRight(String lemma,
+			PartOfSpeech pos) throws LexicalResourceException {
+		
+		return this.theLexicalResource.getRulesForRight(lemma,  pos); 		
+		
+	}
+
+	@Override
+	public List<LexicalRule<? extends RuleInfo>> getRulesForLeft(String lemma,
+			PartOfSpeech pos) throws LexicalResourceException {
+		
+		return this.theLexicalResource.getRulesForLeft(lemma,  pos); 
+		
+	}
+
+	@Override
+	public List<LexicalRule<? extends RuleInfo>> getRules(String leftLemma,
+			PartOfSpeech leftPos, String rightLemma, PartOfSpeech rightPos)
+			throws LexicalResourceException {
+		
+		return this.theLexicalResource.getRules(leftLemma, leftPos, rightLemma, rightPos); 
+		
+	}
+
+	@Override
+	public void close() throws LexicalResourceCloseException {
+		// shutdown the redis server, if it has any. 
+		
+		if (rs_l!=null)
+		{
+			rs_l.stop(); 
+		}
+		if (rs_r!=null)
+		{
+			rs_r.stop(); 
+		}
+	}
+	
+	//
+	// private data 
+	
+	private SimilarityStorageBasedLexicalResource theLexicalResource;
+	private Logger logger; 
+	private EmbeddedRedisServerRunner rs_l = null; 
+	private EmbeddedRedisServerRunner rs_r = null; 
+
+
+	//
+	// private methods 
+	private static File extractDataFileFromResource(URL resource) throws IOException
+	{
+		File tmpDir = Files.createTempDir();
+		tmpDir.deleteOnExit();
+		
+		File rdb = new File(tmpDir, resource.getFile());
+		FileUtils.copyURLToFile(resource, rdb);
+		rdb.deleteOnExit();
+				
+		return rdb; 
+	}
+
+
+
+}

--- a/distsim/src/main/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisServerRunner.java
+++ b/distsim/src/main/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisServerRunner.java
@@ -1,0 +1,209 @@
+package eu.excitementproject.eop.distsim.redisinjar;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.apache.commons.io.FileUtils;
+//import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
+
+/**
+ * This small utility class runs Redis-server with three options. 
+ * Port, RDB file dir, RDB file name. 
+ * 
+ * The class first invokes redis-server binary from Jar (via getResource), and makes one 
+ * copy in a temporary disc location (via Google coreIO library), and runs it as a native process. 
+ * This copy (of file) is automatically destroyed when the JVM closes down. 
+ * 
+ * Usage is simple: init a Redis-server process by using the constructor, start running by calling start(), stop its running by calling stop(). 
+ * See the unit test class for the code usage in action.   
+ * The progress will be reported via log4j INFO level. You can see redis-server output (STDOUT & STDERR) by enabling level.DEBUG of log4j.  
+ * 
+ * DISCLAIMER: I have borrowed a lot of codes (e.g. the idea of using script enum, or using google IO to get file from resource) 
+ * from the following Apache 2.0 licensed library. 
+ * 
+ * The code itself didn't meet our needs (e.g. it does not support passing of 
+ * arguments, configuration, and rdb file); so I extended it fairly for our usage. But still, 
+ * this file contains some of the original code. See the following page for original code. 
+ * https://github.com/kstyrc/embedded-redis
+ * 
+ * @author Tae-Gil Noh 
+ * 
+ * NOTE: designed with REDIS server binary 2.6.16! 
+ * NOTE: tested with Linux-64 and OSX 10.9 
+ * TODO write "redis-based lexical resource implementation base". This can work also 
+ * with "already existing server (by getting server & port)
+ * 
+ */
+public class EmbeddedRedisServerRunner {
+	
+	/* We won't need this. 
+	public RedisServer(File command, Integer port) {
+		this.command = command;
+		this.port = port;
+	}
+	*/ 
+	/**
+	 * This is the main constructor of RedisServerRunner. 
+	 * 
+	 * @param port port number - on what port this redis-server will serve? (passed as --port argument to redis-server binary)
+	 * @param argRDBDir directory of the rdb, on what path the rdb file exist? (without file name, passed as argument --dir to redis-server binary) 
+	 * @param argRDBName filename of the rdb file to be served (without path, just the file name. passed as argument --dbfilename ) 
+	 * @throws IOException
+	 */
+	public EmbeddedRedisServerRunner(Integer port, String argRDBDir, String argRDBName) throws IOException {
+		this.port = port;
+		this.rdbDir = argRDBDir; 
+		this.rdbName = argRDBName; 
+		this.command = extractExecutableFromJar(RedisRunScriptEnum.getRedisRunScript());		
+        logger = Logger.getLogger(getClass().getName()); 
+        logger.debug("redis server constructed with " + port.toString() + ", " + rdbDir + ", " + rdbName); 
+	}
+
+	public EmbeddedRedisServerRunner(Integer port) throws IOException {
+		this(port, null, null); 
+	}
+	
+	private File extractExecutableFromJar(String scriptName) throws IOException {
+		File tmpDir = Files.createTempDir();
+		tmpDir.deleteOnExit();
+
+		File command = new File(tmpDir, scriptName);
+		FileUtils.copyURLToFile(Resources.getResource(scriptName), command);
+		command.deleteOnExit();
+		command.setExecutable(true);
+		
+		return command;
+	}
+	
+	public boolean isActive() {
+		return active;
+	}
+
+	public synchronized void start() throws IOException {
+		if (active) {
+			throw new RuntimeException("This redis server instance is already running...");
+		}
+		
+		logger.info("starting up redis server on port " + port.toString() + " (--dir:" + rdbDir + ", --dbfilename:" + rdbName + ")"); 
+
+		redisProcess = createRedisProcessBuilder().start();
+		portReady = awaitRedisServerReady(); // returns true, if it catches "server is now ready" comment. 
+		active = true;
+		
+		if (portReady)
+			logger.info("redis server up and running on port " + port.toString() + " (--dir:" + rdbDir + ", --dbfilename:" + rdbName + ")"); 
+		else
+		{
+			logger.warn("redis server executed, but could not check its running on the designated port! (" + port.toString() + ", --dir:" + rdbDir + ", --dbfilename:" + rdbName + ")."); 
+			logger.warn("It may be okay; but more likely a problem! Set log4j level to DEBUG to check the redis-server output. "); 				
+		}
+	}
+
+	private Boolean awaitRedisServerReady() throws IOException {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(redisProcess.getInputStream()));
+		Boolean portReady = false; 
+		
+		// do we have to put some small "wait" here? what if the process starts, say, 
+		// very late? Hmm. or should we wait for first line? 
+		try {
+			String outputLine = null;
+			do {
+				outputLine = reader.readLine();
+				logger.debug(outputLine); // log4j debug-level output, so we know what goes around, if needed. 
+				if (outputLine != null)
+				{
+					if (outputLine.matches(REDIS_READY_PATTERN))
+					{
+						portReady = true; // successfully ran the Redis-server. 
+						break; 
+					}
+				}
+			} while (outputLine != null); //  && !outputLine.matches(REDIS_READY_PATTERN));
+		} finally {
+			reader.close();
+		}
+		return portReady; 
+	}
+
+	private ProcessBuilder createRedisProcessBuilder() {
+		
+		ProcessBuilder pb = null; 
+		if ((rdbDir == null) || (rdbName == null))
+		{
+			pb = new ProcessBuilder(command.getAbsolutePath(), "--port", Integer.toString(port));
+			pb.directory(command.getParentFile());
+		}
+		else
+		{
+			pb = new ProcessBuilder(command.getAbsolutePath(), "--port", Integer.toString(port), "--dir", rdbDir, "--dbfilename", rdbName);
+			pb.directory(command.getParentFile());			
+		}
+		pb.redirectErrorStream(true); // both STDERR/STDOUT via  getInputStream:  needed for rare cases where run fails due to GLIBC problem, etc. 
+		return pb;
+	}
+
+	public synchronized void stop() {
+		if (active) {
+			redisProcess.destroy();
+			active = false;
+		}
+		
+		logger.info("redis server process for port " + port.toString() + " destroyed. (--dir:" + rdbDir + ", --dbfilename:" + rdbName + ")"); 
+	}
+	
+	private static enum RedisRunScriptEnum {
+		WINDOWS_32("embedded-redis/redis-server.exe"),
+		WINDOWS_64("embedded-redis/redis-server-64.exe"),
+		LINUX_32("embedded-redis/redis-server"),
+		LINUX_64("embedded-redis/redis-server-64"), 
+		MACOSX("embedded-redis/redis-server.app");
+		
+		private final String runScript;
+
+		private RedisRunScriptEnum(String runScript) {
+			this.runScript = runScript;
+		}
+		
+		public static String getRedisRunScript() {
+			String osName = System.getProperty("os.name");
+			String osArch = System.getProperty("os.arch");
+			
+			if (osName.indexOf("win") >= 0) {
+				if (osArch.indexOf("64") >= 0) {
+					return WINDOWS_64.runScript;
+				} else {
+					return WINDOWS_32.runScript;
+				}
+			} else if (osName.indexOf("nix") >= 0 || osName.indexOf("nux") >= 0 || osName.indexOf("aix") > 0) {
+				if (osArch.indexOf("64") >= 0) {
+					return LINUX_64.runScript; 
+				} else {
+					return LINUX_32.runScript;
+				}
+			} else if ("Mac OS X".equals(osName)) {
+				return MACOSX.runScript;
+			} else {
+				throw new RuntimeException("Unsupported os/architecture...: " + osName + " on " + osArch);
+			}
+		}
+	}
+	
+	private static final String REDIS_READY_PATTERN = ".*The server is now ready to accept connections on port.*";
+
+	private final File command;
+	private final Integer port;
+	private final String rdbDir; 
+	private final String rdbName; 
+	private final Logger logger; 
+	
+	private volatile boolean active = false;
+	private volatile boolean portReady = false; 
+	private Process redisProcess;
+	
+}

--- a/distsim/src/main/java/eu/excitementproject/eop/distsim/redisinjar/package-info.java
+++ b/distsim/src/main/java/eu/excitementproject/eop/distsim/redisinjar/package-info.java
@@ -1,0 +1,9 @@
+
+/**
+ * 
+ * The package holds code that enables run redis-server binaries from a Jar. 
+ * 
+ * @author Tae-Gil Noh
+ *
+ */
+package eu.excitementproject.eop.distsim.redisinjar;

--- a/distsim/src/main/java/eu/excitementproject/eop/distsim/resource/TestLemmaPosSimilarityGerman.java
+++ b/distsim/src/main/java/eu/excitementproject/eop/distsim/resource/TestLemmaPosSimilarityGerman.java
@@ -1,0 +1,93 @@
+package eu.excitementproject.eop.distsim.resource;
+
+import java.util.List;
+
+
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalResource;
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalResourceException;
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalRule;
+import eu.excitementproject.eop.common.component.lexicalknowledge.RuleInfo;
+import eu.excitementproject.eop.common.representation.partofspeech.ByCanonicalPartOfSpeech;
+import eu.excitementproject.eop.common.representation.partofspeech.CanonicalPosTag;
+import eu.excitementproject.eop.common.representation.partofspeech.GermanPartOfSpeech;
+import eu.excitementproject.eop.common.representation.partofspeech.UnsupportedPosTagStringException;
+import eu.excitementproject.eop.common.utilities.configuration.ConfigurationException;
+import eu.excitementproject.eop.common.utilities.configuration.ConfigurationFile;
+import eu.excitementproject.eop.common.utilities.configuration.ConfigurationFileDuplicateKeyException;
+import eu.excitementproject.eop.common.utilities.configuration.ConfigurationParams;
+import eu.excitementproject.eop.distsim.storage.ElementTypeException;
+import eu.excitementproject.eop.distsim.storage.RedisBasedStringListBasicMap;
+import eu.excitementproject.eop.distsim.storage.SimilarityNotFoundException;
+import eu.excitementproject.eop.distsim.storage.SimilarityStorage;
+import eu.excitementproject.eop.distsim.storage.DefaultSimilarityStorage;
+import eu.excitementproject.eop.distsim.util.Configuration;
+
+/**
+ * A program which demonstrates how to access a given distributional similarity model via Lexical interface, 
+ * stored in Redis dbs, given by the l2r and r-2l similarity dbs
+ * 
+ * 
+ * @author Meni Adler
+ * @since 07/01/2013
+ *
+ */
+public class TestLemmaPosSimilarityGerman {
+	
+	public static void main(String[] args) throws SimilarityNotFoundException, LexicalResourceException, UnsupportedPosTagStringException, ConfigurationFileDuplicateKeyException, ConfigurationException, ElementTypeException {
+		
+		
+		
+//		if (args.length != 1) {
+//			System.out.println("Usage: eu.excitementproject.eop.distsim.application.TestLemmaPosSimilarity <configuration file>");
+//			System.exit(0);
+//		}
+		
+//		ConfigurationFile confFile = new ConfigurationFile(args[0]);
+//		ConfigurationParams confParams = confFile.getModuleConfiguration(Configuration.KNOWLEDGE_RESOURCE);
+
+//		LexicalResource<? extends RuleInfo> resource = new SimilarityStorageBasedLexicalResource(confParams);
+		
+		// LIN-GER PROX (no nouns!!! hmm. ) 
+		RedisBasedStringListBasicMap l2r = new RedisBasedStringListBasicMap("gillespie.cl.uni-heidelberg.de", 6379);
+		RedisBasedStringListBasicMap r2l = new RedisBasedStringListBasicMap("gillespie.cl.uni-heidelberg.de", 6380); 
+
+		// LIN-GER DEP (also no nouns!! ... hmm no "gut", but "blau", "recht" okay.) 
+		//RedisBasedStringListBasicMap l2r = new RedisBasedStringListBasicMap("gillespie.cl.uni-heidelberg.de", 6381);
+		//RedisBasedStringListBasicMap r2l = new RedisBasedStringListBasicMap("gillespie.cl.uni-heidelberg.de", 6382); 
+
+		// BAP-GER 
+		// too small... 
+		
+		
+		SimilarityStorage ss = new DefaultSimilarityStorage(l2r, r2l, "GermanLin", "inst1", "eu.excitementproject.eop.distsim.items.LemmaPosBasedElement"); 
+		LexicalResource<? extends RuleInfo> resource = new SimilarityStorageBasedLexicalResource(ss);
+
+		List<? extends LexicalRule<? extends RuleInfo>> similarities = resource.getRulesForLeft("ewig", null); 
+		
+		System.out.println("left-2-right rules: ");
+		for (LexicalRule<? extends RuleInfo> similarity : similarities)
+			System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+
+//		List<? extends LexicalRule<? extends RuleInfo>> similarities = resource.getRulesForLeft("affect",null);
+//		System.out.println("left-2-right rules for affect: ");
+//		for (LexicalRule<? extends RuleInfo> similarity : similarities)
+//			System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+//		
+//		similarities = resource.getRulesForRight("affect",null);
+//		System.out.println("\nright-2-left rules for affect: ");
+//		for (LexicalRule<? extends RuleInfo> similarity : similarities)
+//			System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+//
+//	
+//		similarities = resource.getRulesForLeft("affect",new ByCanonicalPartOfSpeech(CanonicalPosTag.V.name()));
+//		System.out.println("\nleft-2-right rules for affect as a verb: ");
+//		for (LexicalRule<? extends RuleInfo> similarity : similarities)
+//			System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+//
+//		similarities = resource.getRulesForRight("affect",new ByCanonicalPartOfSpeech(CanonicalPosTag.V.name()));
+//		System.out.println("\nright-2-left rules for affect as a verb: ");
+//		for (LexicalRule<? extends RuleInfo> similarity : similarities)
+//			System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+
+	}
+}

--- a/distsim/src/test/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisBasedLexicalResourceTest.java
+++ b/distsim/src/test/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisBasedLexicalResourceTest.java
@@ -1,0 +1,114 @@
+package eu.excitementproject.eop.distsim.redisinjar;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+import java.net.URL;
+import java.util.List;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalRule;
+import eu.excitementproject.eop.common.component.lexicalknowledge.RuleInfo;
+
+public class EmbeddedRedisBasedLexicalResourceTest {
+
+	// Hello, this test class also shows the usage of the 
+	// EmbeddedRedisBasedLexicalResource. --- you only need to provide 
+	// the rdb model file in the classpath (in a Jar of an artifact). 
+	//
+	// You can check how you can use EmbeddedRedisBasedLexicalResource 
+	// by following the test code. 
+	
+	// Q1: How to run this test? 
+	//
+	// As it is, the test is not executed and simply passed, 
+	// if the redis-db files are not present in classpath. 
+	// 1. Remove comment and add back artifact "redis-german-lin-prox"
+	//    in distsim/pom.xml. 
+	// 		This artifact is currently commented out, 
+	//      because of the model file's size.
+ 	// 2. Run the test. Check the code to see how you can use. 
+	
+	// Q2: Okay. I understand how it works with rdb file in Jar. 
+	//    But how I put my rdb files in Jar? 
+	// 
+	// 1. Generate redis model, as "distsim" tool manual describes. 
+	// 2. locate the two rdb files (L->R and R->L), pack them with a 
+	//    unique classpath in jar. (e.g.  jar:/resourceName/rdbfilename) 
+	// 3. Make the Jar as an artifact, by deploying it in the repository.  
+	// 4. Then, you code can locate those rdb files from Jar, just as the 
+	//    same way this usage code locates redis-german-lin-prox files. 
+	//    (e.g. getClassLoader().getResource("path/rdbfilename") ) 
+	
+	@Test
+	public void test() {
+		// If you are reading this test file to check usage,
+		// make sure you read till the end (close() call is a must, etc). 
+		
+        Logger.getRootLogger().setLevel(Level.INFO); // (hiding < INFO)
+        Logger testLogger = Logger.getLogger(EmbeddedRedisBasedLexicalResourceTest.class.getName()); 
+        // This test class also shows the usage of RedisBasedLexicalResource class 
+
+        // To initiate the resource, you first need to locate the Redis RDB file in Jar.         
+        // let's test it with german lin 
+        // Note that, the artifact (it's Jar file) holds redis model file in 
+        // classpath "redis-german-lin/similarity-l2r.rdb" and "redis-german-lin/similarity-r2l.rdb"
+        // You can also pack RDB files in a Jar and make an artifact by deploying it. 
+		URL l2rResource = EmbeddedRedisServerRunnerTest.class.getClassLoader().getResource("redis-german-lin/similarity-l2r.rdb"); 
+		URL r2lResource = EmbeddedRedisServerRunnerTest.class.getClassLoader().getResource("redis-german-lin/similarity-r2l.rdb"); 
+
+		// if those rdb files are not in classpath (e.g. the artifacts are not added in POM)
+		// simply ignore this test, since we can't test. 
+		if (l2rResource == null || r2lResource == null)
+		{
+			testLogger.info("Rdb model files are not found in classpath (artifact not added in POM) - This is Okay, we skip this test."); 
+		}
+		assumeNotNull(l2rResource); 
+		assumeNotNull(r2lResource); 
+		
+		// We have the file resource URL. Time to initiate RedisBasedLexicalResource. 
+		EmbeddedRedisBasedLexicalResource testResource=null; 
+		try {
+			 testResource = new EmbeddedRedisBasedLexicalResource(l2rResource, r2lResource, 6379, 6380, 20); 
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace(); 
+			fail (e.getMessage()); 		
+		}
+		assertNotNull(testResource); 
+		
+		// Okay. The resource is ready. time to send some queries as test. 
+		try {
+			List<? extends LexicalRule<? extends RuleInfo>> similarities_l = testResource.getRulesForLeft("ewig", null); 
+			System.out.println("left-2-right rules: ");
+			for (LexicalRule<? extends RuleInfo> similarity : similarities_l)
+				System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+
+			List<? extends LexicalRule<? extends RuleInfo>> similarities_r = testResource.getRulesForRight("ewig", null); 
+			System.out.println("right-2-left rules: ");
+			for (LexicalRule<? extends RuleInfo> similarity : similarities_r)
+				System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+		
+		
+		} catch (Exception e)
+		{
+			e.printStackTrace(); 
+			fail(e.getMessage());  			
+		}
+		
+		// Note that you *MUST* call close() all the time, other wise
+		// the underlying redis-server does not closes!  
+		try {
+			testResource.close(); 
+		} catch (Exception e)
+		{
+			e.printStackTrace(); 
+			fail(e.getMessage());  						
+		}
+	}
+
+}

--- a/distsim/src/test/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisServerRunnerTest.java
+++ b/distsim/src/test/java/eu/excitementproject/eop/distsim/redisinjar/EmbeddedRedisServerRunnerTest.java
@@ -1,0 +1,153 @@
+package eu.excitementproject.eop.distsim.redisinjar;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.google.common.io.Files;
+
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalResource;
+import eu.excitementproject.eop.common.component.lexicalknowledge.LexicalRule;
+import eu.excitementproject.eop.common.component.lexicalknowledge.RuleInfo;
+import eu.excitementproject.eop.distsim.resource.SimilarityStorageBasedLexicalResource;
+import eu.excitementproject.eop.distsim.storage.DefaultSimilarityStorage;
+import eu.excitementproject.eop.distsim.storage.RedisBasedStringListBasicMap;
+import eu.excitementproject.eop.distsim.storage.SimilarityStorage;
+
+public class EmbeddedRedisServerRunnerTest {
+
+	// ignored for now; we need more through "binary" test.
+	// TODO: check with FBK computers. 
+	// TODO: check with Windows computers. (hate that but well) 
+	
+	@Ignore   
+	@Test
+	public void test() {
+		
+        Logger.getRootLogger().setLevel(Level.INFO); // (hiding < INFO)
+
+		// Simple running itself. Without specifying rdb file. (won't create/load any) 
+		EmbeddedRedisServerRunner rs = null; 		
+		try {
+			rs = new EmbeddedRedisServerRunner(6371); 
+			rs.start();
+			// no need // Thread.sleep(5000); 
+		} catch (Exception e)
+		{
+			System.out.println("Redis Server runner raised an exception: " + e.getMessage()); 
+			e.printStackTrace(); 
+			fail("Redis server runner test failed."); 
+		}
+		assertNotNull(rs); 
+		rs.stop(); 
+		
+		// Running with a specific RDB file. 
+		// first check that the files are in classpath. If not, just ignore 
+		// the rest of the test. 
+		URL l2rResource = EmbeddedRedisServerRunnerTest.class.getClassLoader().getResource("redis-german-lin/similarity-l2r.rdb"); 
+		URL r2lResource = EmbeddedRedisServerRunnerTest.class.getClassLoader().getResource("redis-german-lin/similarity-r2l.rdb"); 
+
+		assumeNotNull(l2rResource); 
+		assumeNotNull(r2lResource); 
+		
+		// The following test will be done only when there is 
+		// redis-german-lin/  rdb files are in classpath (artifact/Jar). 
+		
+		EmbeddedRedisServerRunner rs_l = null; 
+		EmbeddedRedisServerRunner rs_r = null; 
+		try {
+//			rs_l = new RedisServerRunner(6379, "/home/tailblues/temp/", "similarity-l2r.rdb"); 
+//			rs_r = new RedisServerRunner(6380, "/home/tailblues/temp/", "similarity-r2l.rdb"); 
+			System.out.println("extracting l2r file");
+			//File l2rRdb = extractDataFileFromJar("redis-german-lin/similarity-l2r.rdb");
+			File l2rRdb = extractDataFileFromResource(l2rResource); 
+			System.out.println("extracted in: " + l2rRdb.getParent() + "//" + l2rRdb.getName()); 
+			System.out.println("extracting r2l file");
+			//File r2lRdb = extractDataFileFromJar("redis-german-lin/similarity-r2l.rdb"); 
+			File r2lRdb = extractDataFileFromResource(r2lResource); 
+			System.out.println("extracted in: " + r2lRdb.getParent() + "//" + r2lRdb.getName()); 
+//			rs_l = new RedisServerRunner(6379, "/Users/tailblues/temp", "similarity-l2r.rdb"); 
+//			rs_r = new RedisServerRunner(6380, "/Users/tailblues/temp", "similarity-r2l.rdb"); 
+			rs_l = new EmbeddedRedisServerRunner(6379, l2rRdb.getParent(), l2rRdb.getName()); 
+			rs_r = new EmbeddedRedisServerRunner(6380, r2lRdb.getParent(), r2lRdb.getName()); 
+			
+			// run 
+			rs_l.start();
+			//Thread.sleep(1000); // do we need this? no. 
+			rs_r.start(); 
+			//Thread.sleep(5000); 
+
+		} catch (Exception e)
+		{
+			System.out.println("Redis Server runner raised an exception: " + e.getMessage()); 
+			e.printStackTrace(); 
+			fail("Redis server runner test failed."); 
+		}
+		assertNotNull(rs_l); 
+		assertNotNull(rs_r); 
+
+
+		// Reading testing sequence 
+		RedisBasedStringListBasicMap l2r = new RedisBasedStringListBasicMap("127.0.0.1", 6379);
+		RedisBasedStringListBasicMap r2l = new RedisBasedStringListBasicMap("127.0.0.1", 6380); 
+		
+		SimilarityStorage ss = new DefaultSimilarityStorage(l2r, r2l, "GermanLin", "inst1", "eu.excitementproject.eop.distsim.items.LemmaPosBasedElement"); 
+		LexicalResource<? extends RuleInfo> resource = new SimilarityStorageBasedLexicalResource(ss, 10);
+
+		try {
+			List<? extends LexicalRule<? extends RuleInfo>> similarities_l = resource.getRulesForLeft("ewig", null); 
+			System.out.println("left-2-right rules: ");
+			for (LexicalRule<? extends RuleInfo> similarity : similarities_l)
+				System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+
+			List<? extends LexicalRule<? extends RuleInfo>> similarities_r = resource.getRulesForRight("ewig", null); 
+			System.out.println("right-2-left rules: ");
+			for (LexicalRule<? extends RuleInfo> similarity : similarities_r)
+				System.out.println("<" + similarity.getLLemma() + "," + similarity.getLPos() + ">" + " --> " + "<" + similarity.getRLemma() + "," + similarity.getRPos() + ">" + ": " + similarity.getConfidence());
+		
+		
+		} catch (Exception e)
+		{
+			System.out.println("Lexical resource access via Redis Server runner raised an exception: " + e.getMessage()); 
+			e.printStackTrace(); 
+			fail("Redis server runner test failed."); 			
+		}
+		
+		rs_l.stop();
+		rs_r.stop(); 
+		
+	}
+	
+	private static File extractDataFileFromResource(URL resource) throws IOException
+	{
+		File tmpDir = Files.createTempDir();
+		tmpDir.deleteOnExit();
+		
+		File rdb = new File(tmpDir, resource.getFile());
+		FileUtils.copyURLToFile(resource, rdb);
+		rdb.deleteOnExit();
+				
+		return rdb; 
+	}
+	
+//	private static File extractDataFileFromJar(String resourceName) throws IOException {
+//		File tmpDir = Files.createTempDir();
+//		tmpDir.deleteOnExit();
+//
+//		File rdb = new File(tmpDir, resourceName);
+//		FileUtils.copyURLToFile(Resources.getResource(resourceName), rdb);
+//		rdb.deleteOnExit();
+//		
+//		return rdb;
+//	}
+
+}


### PR DESCRIPTION
The new class is adding the ability to run redis-server (almost) transparently to the caller side. It enables running redis-server that is stored in the jar, to load a rdb model file which is also stored in a Jar. 

See EmbeddedRedisBasedLexicalResourceTest class to see the usage. 
