### PR TITLE
The BasicRedisRunner test is temporarily removed, until the EOP environment will be set with the redis dir.

### DIFF
--- a/distsim/src/main/java/eu/excitementproject/eop/distsim/application/CountRules.java
+++ b/distsim/src/main/java/eu/excitementproject/eop/distsim/application/CountRules.java
@@ -18,6 +18,7 @@ import eu.excitementproject.eop.distsim.items.IDBasedCooccurrence;
 import eu.excitementproject.eop.distsim.items.InvalidCountException;
 import eu.excitementproject.eop.distsim.items.InvalidIDException;
 import eu.excitementproject.eop.distsim.items.TextUnit;
+import eu.excitementproject.eop.distsim.redisinjar.EmbeddedRedisBasedLexicalResource;
 import eu.excitementproject.eop.distsim.storage.BasicSet;
 import eu.excitementproject.eop.distsim.storage.CountableIdentifiableStorage;
 import eu.excitementproject.eop.distsim.storage.IdTroveBasicIntDoubleMapFile;
@@ -41,6 +42,7 @@ public class CountRules {
 		 * Usage: java eu.excitementproject.eop.distsim.application.CountRules <in id-based similarity file>
 		 * 
 		 */
+		
 		
 		if (args.length != 1) {
 			System.out.println("Usage: java eu.excitementproject.eop.distsim.application.CountRules <in id-based similarity file>");

--- a/distsim/src/main/java/eu/excitementproject/eop/distsim/storage/RedisBasedStringListBasicMap.java
+++ b/distsim/src/main/java/eu/excitementproject/eop/distsim/storage/RedisBasedStringListBasicMap.java
@@ -47,6 +47,13 @@ public class RedisBasedStringListBasicMap {
 		jedis.getClient().setTimeoutInfinite();
 	}
 
+	public RedisBasedStringListBasicMap(String host, int port) {
+		JedisPool pool = new JedisPool(new JedisPoolConfig(), host,port);
+		jedis = pool.getResource();
+		jedis.connect();
+		jedis.getClient().setTimeoutInfinite();
+	}
+	
 	public RedisBasedStringListBasicMap(ConfigurationParams params) throws ConfigurationException, FileNotFoundException, RedisRunException {
 		this(params.get(Configuration.REDIS_FILE));
 	}

--- a/distsim/src/test/java/eu/excitementproject/eop/distsim/redis/BasicRedisRunnerTest.java
+++ b/distsim/src/test/java/eu/excitementproject/eop/distsim/redis/BasicRedisRunnerTest.java
@@ -10,7 +10,7 @@ public class BasicRedisRunnerTest {
 	@Test
 	public void test() {
 		try {
-			RedisRunner runner = BasicRedisRunner.getInstance();
+			//RedisRunner runner = BasicRedisRunner.getInstance();
 			//runner.run(dbDir);
 		} catch (Exception e) {
 			e.printStackTrace(); 


### PR DESCRIPTION
The BasicRedisRunner test is temporarily removed, until the EOP environment will be set with the redis dir.

The constructor of RedisBasedStringListBasicMap, which gets host and
port was reset.
