### PR TITLE
Better tokenizer for TreeTagger pipeline (TreeTaggerLN) 

### DIFF
--- a/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerEN.java
+++ b/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerEN.java
@@ -9,8 +9,9 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 //import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 //import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.ResourceInitializationException;
+import de.tudarmstadt.ukp.dkpro.core.opennlp.OpenNlpSegmenter;
 //import org.uimafit.factory.AggregateBuilder;
-import de.tudarmstadt.ukp.dkpro.core.tokit.BreakIteratorSegmenter;
+//import de.tudarmstadt.ukp.dkpro.core.tokit.BreakIteratorSegmenter;
 import de.tudarmstadt.ukp.dkpro.core.treetagger.TreeTaggerPosLemmaTT4J;
 
 import eu.excitementproject.eop.lap.LAPAccess;
@@ -49,7 +50,8 @@ public class TreeTaggerEN extends LAP_ImplBaseAE implements LAPAccess {
 		AnalysisEngineDescription[] descArr = new AnalysisEngineDescription[2];
 		try 
 		{
-			descArr[0] = createPrimitiveDescription(BreakIteratorSegmenter.class);
+			descArr[0] = createPrimitiveDescription(OpenNlpSegmenter.class);
+			//descArr[0] = createPrimitiveDescription(BreakIteratorSegmenter.class);
 			descArr[1] = createPrimitiveDescription(TreeTaggerPosLemmaTT4J.class); 
 		}
 		catch (ResourceInitializationException e)

--- a/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerDETest.java
+++ b/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerDETest.java
@@ -10,7 +10,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.uima.jcas.JCas;
 import org.junit.Assume;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 import eu.excitementproject.eop.lap.LAPAccess;
@@ -20,7 +20,7 @@ import eu.excitementproject.eop.lap.dkpro.TreeTaggerDE;
 
 public class TreeTaggerDETest {
 
-	@Ignore
+//	@Ignore
 	@Test
 	public void testAddAnnotationOnJCasString() {
 		

--- a/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerEnTest.java
+++ b/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerEnTest.java
@@ -10,7 +10,7 @@ import org.apache.log4j.Logger;
 import org.apache.commons.lang.exception.ExceptionUtils; 
 import org.apache.uima.jcas.JCas;
 import org.junit.Assume;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 import eu.excitementproject.eop.lap.LAPAccess;
@@ -20,7 +20,7 @@ import eu.excitementproject.eop.lap.dkpro.TreeTaggerEN;
 
 public class TreeTaggerEnTest {
 
-	@Ignore
+//	@Ignore
 	@Test
 	public void test() {
 
@@ -44,10 +44,10 @@ public class TreeTaggerEnTest {
 			// If it does not, it raises an LAPException. 
 			// It will also print the summarized data of the CAS to the PrintStream. 
 			// If the second argument is null, it will only check the format and raise Exceptions, without printing 
-			PlatformCASProber.probeCas(aJCas, System.out); 
+			//PlatformCASProber.probeCas(aJCas, System.out); 
 			
 			// To see the full content of each View, use this 
-			//PlatformCASProber.probeCasAndPrintContent(aJCas, System.out); 
+			PlatformCASProber.probeCasAndPrintContent(aJCas, System.out); 
 
 		}
 		catch(LAPException e)
@@ -84,6 +84,16 @@ public class TreeTaggerEnTest {
 		File testXmi = new File("./target/3.xmi"); // you can pick and probe any XMI..  
 		try {
 			PlatformCASProber.probeXmi(testXmi, System.out);
+		} catch (LAPException e) {
+			fail(e.getMessage()); 
+		} 
+
+
+		try {
+			aJCas = lap.generateSingleTHPairCAS("China's victory?", "Korea's defeat?"); 
+			// 's should work okay, but I won't put it as test condition. 
+			//PlatformCASProber.probeCasAndPrintContent(aJCas, System.out);
+
 		} catch (LAPException e) {
 			fail(e.getMessage()); 
 		} 

--- a/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerITTest.java
+++ b/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/TreeTaggerITTest.java
@@ -8,7 +8,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.uima.jcas.JCas;
 import org.junit.Assume;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 import eu.excitementproject.eop.lap.LAPAccess;
@@ -17,7 +17,7 @@ import eu.excitementproject.eop.lap.PlatformCASProber;
 
 public class TreeTaggerITTest {
 
-	@Ignore
+//	@Ignore
 	@Test
 	public void test() {
 	


### PR DESCRIPTION
Exchanged the simplest (breakiteratorsegmenter) tokenizer to a model based (open-nlp) tokenizer. 
Unit tests are now un- @ignore -d. (hope Jenkins is all okay) 
