### PR TITLE
updated alignment.Link types, according to v3 proposal

### DIFF
--- a/common/src/main/java/eu/excitement/type/alignment/Link.java
+++ b/common/src/main/java/eu/excitement/type/alignment/Link.java
@@ -7,17 +7,21 @@ import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.JCasRegistry;
 import org.apache.uima.jcas.cas.TOP_Type;
 
+import org.apache.uima.jcas.cas.StringList;
 import org.apache.uima.jcas.tcas.Annotation;
 
 
 /** - CAS type that links two Target. 
 - Multi-view type: a Link connects one target in T (TextView), the other target in H (HypothesisView). 
-- Three features: "from" (alignment.Target), "to" (alignment.Target), and "strength" (double). 
 
-The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to". 
+The semantic of a "Link" is: The texts (or structures) pointed by "TSideTarget" and "HSideTarget" have a relation of "type", with the direction of "direction",  on a strength of "strength". 
 
- We make no assumptions regarding what annotations are aligned by Link and Target types. One Target can be linked by an arbitrary number of Link, also a Target can group an arbitrary number of Annotations. Note that uima.tcas.Annotation is the super type of almost all CAS annotation data. Since a Target can group Annotation, it can group any type of annotations in CAS. 
- * Updated by JCasGen Thu Apr 24 15:21:08 CEST 2014
+We make no assumptions regarding what annotations are aligned by Link and Target types. One Target can be linked by an arbitrary number of Link, also a Target can group an arbitrary number of Annotations. Note that uima.tcas.Annotation is the super type of almost all CAS annotation data. Since a Target can group Annotation, it can group any type of annotations in CAS.
+
+Some notes on Link type usage. (Indexing and setting begin - end) 
+- A Link instance should be indexed on the Hypothesis View. So one iteration over the Hypothesis view can get all alignment links.
+- begin and end : both span value should hold the same value to that of HSide Target 
+ * Updated by JCasGen Tue May 06 15:54:34 CEST 2014
  * XML source: /home/tailblues/progs/Excitement-Open-Platform/common/src/main/resources/desc/type/AlignmentTypes.xml
  * @generated */
 public class Link extends Annotation {
@@ -69,39 +73,39 @@ public class Link extends Annotation {
  
     
   //*--------------*
-  //* Feature: from
+  //* Feature: TSideTarget
 
-  /** getter for from - gets This feature points one Target. Mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to". 
+  /** getter for TSideTarget - gets This feature points one Target in TEXTVIEW side. A mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) targets have the relation of "type" between them, with the direction of "direction".
    * @generated */
-  public Target getFrom() {
-    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_from == null)
-      jcasType.jcas.throwFeatMissing("from", "eu.excitement.type.alignment.Link");
-    return (Target)(jcasType.ll_cas.ll_getFSForRef(jcasType.ll_cas.ll_getRefValue(addr, ((Link_Type)jcasType).casFeatCode_from)));}
+  public Target getTSideTarget() {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_TSideTarget == null)
+      jcasType.jcas.throwFeatMissing("TSideTarget", "eu.excitement.type.alignment.Link");
+    return (Target)(jcasType.ll_cas.ll_getFSForRef(jcasType.ll_cas.ll_getRefValue(addr, ((Link_Type)jcasType).casFeatCode_TSideTarget)));}
     
-  /** setter for from - sets This feature points one Target. Mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to".  
+  /** setter for TSideTarget - sets This feature points one Target in TEXTVIEW side. A mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) targets have the relation of "type" between them, with the direction of "direction". 
    * @generated */
-  public void setFrom(Target v) {
-    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_from == null)
-      jcasType.jcas.throwFeatMissing("from", "eu.excitement.type.alignment.Link");
-    jcasType.ll_cas.ll_setRefValue(addr, ((Link_Type)jcasType).casFeatCode_from, jcasType.ll_cas.ll_getFSRef(v));}    
+  public void setTSideTarget(Target v) {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_TSideTarget == null)
+      jcasType.jcas.throwFeatMissing("TSideTarget", "eu.excitement.type.alignment.Link");
+    jcasType.ll_cas.ll_setRefValue(addr, ((Link_Type)jcasType).casFeatCode_TSideTarget, jcasType.ll_cas.ll_getFSRef(v));}    
    
     
   //*--------------*
-  //* Feature: to
+  //* Feature: HSideTarget
 
-  /** getter for to - gets This feature points one Target. Mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to". 
+  /** getter for HSideTarget - gets This feature points one Target in HYPOTHESISVIEW side. A mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) targets have the relation of "type" between them, with the direction of "direction".
    * @generated */
-  public Target getTo() {
-    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_to == null)
-      jcasType.jcas.throwFeatMissing("to", "eu.excitement.type.alignment.Link");
-    return (Target)(jcasType.ll_cas.ll_getFSForRef(jcasType.ll_cas.ll_getRefValue(addr, ((Link_Type)jcasType).casFeatCode_to)));}
+  public Target getHSideTarget() {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_HSideTarget == null)
+      jcasType.jcas.throwFeatMissing("HSideTarget", "eu.excitement.type.alignment.Link");
+    return (Target)(jcasType.ll_cas.ll_getFSForRef(jcasType.ll_cas.ll_getRefValue(addr, ((Link_Type)jcasType).casFeatCode_HSideTarget)));}
     
-  /** setter for to - sets This feature points one Target. Mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to".  
+  /** setter for HSideTarget - sets This feature points one Target in HYPOTHESISVIEW side. A mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) targets have the relation of "type" between them, with the direction of "direction". 
    * @generated */
-  public void setTo(Target v) {
-    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_to == null)
-      jcasType.jcas.throwFeatMissing("to", "eu.excitement.type.alignment.Link");
-    jcasType.ll_cas.ll_setRefValue(addr, ((Link_Type)jcasType).casFeatCode_to, jcasType.ll_cas.ll_getFSRef(v));}    
+  public void setHSideTarget(Target v) {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_HSideTarget == null)
+      jcasType.jcas.throwFeatMissing("HSideTarget", "eu.excitement.type.alignment.Link");
+    jcasType.ll_cas.ll_setRefValue(addr, ((Link_Type)jcasType).casFeatCode_HSideTarget, jcasType.ll_cas.ll_getFSRef(v));}    
    
     
   //*--------------*
@@ -120,6 +124,128 @@ public class Link extends Annotation {
     if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_strength == null)
       jcasType.jcas.throwFeatMissing("strength", "eu.excitement.type.alignment.Link");
     jcasType.ll_cas.ll_setDoubleValue(addr, ((Link_Type)jcasType).casFeatCode_strength, v);}    
+   
+    
+  //*--------------*
+  //* Feature: direction
+
+  /** getter for direction - gets This value denotes the "direction" of the alignment.Link. Enum-like value that holds one of "TtoH", "HtoT", or "Symmetric". 
+
+   * @generated */
+  public String getDirection() {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_direction == null)
+      jcasType.jcas.throwFeatMissing("direction", "eu.excitement.type.alignment.Link");
+    return jcasType.ll_cas.ll_getStringValue(addr, ((Link_Type)jcasType).casFeatCode_direction);}
+    
+  /** setter for direction - sets This value denotes the "direction" of the alignment.Link. Enum-like value that holds one of "TtoH", "HtoT", or "Symmetric". 
+ 
+   * @generated */
+  public void setDirection(String v) {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_direction == null)
+      jcasType.jcas.throwFeatMissing("direction", "eu.excitement.type.alignment.Link");
+    jcasType.ll_cas.ll_setStringValue(addr, ((Link_Type)jcasType).casFeatCode_direction, v);}    
+   
+    
+  //*--------------*
+  //* Feature: alignerID
+
+  /** getter for alignerID - gets This is the first part of 3 ID strings for the alignment.Link instance. The string denotes the idetification of the aligner (or underlying resource). 
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info 
+   * @generated */
+  public String getAlignerID() {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_alignerID == null)
+      jcasType.jcas.throwFeatMissing("alignerID", "eu.excitement.type.alignment.Link");
+    return jcasType.ll_cas.ll_getStringValue(addr, ((Link_Type)jcasType).casFeatCode_alignerID);}
+    
+  /** setter for alignerID - sets This is the first part of 3 ID strings for the alignment.Link instance. The string denotes the idetification of the aligner (or underlying resource). 
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info  
+   * @generated */
+  public void setAlignerID(String v) {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_alignerID == null)
+      jcasType.jcas.throwFeatMissing("alignerID", "eu.excitement.type.alignment.Link");
+    jcasType.ll_cas.ll_setStringValue(addr, ((Link_Type)jcasType).casFeatCode_alignerID, v);}    
+   
+    
+  //*--------------*
+  //* Feature: version
+
+  /** getter for version - gets This is the second part of 3 ID strings for the alignment.Link instance. The string denotes the sub-identification of the aligner (or underlying resource) --- which are generally the version (or date).  
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info 
+   * @generated */
+  public String getVersion() {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_version == null)
+      jcasType.jcas.throwFeatMissing("version", "eu.excitement.type.alignment.Link");
+    return jcasType.ll_cas.ll_getStringValue(addr, ((Link_Type)jcasType).casFeatCode_version);}
+    
+  /** setter for version - sets This is the second part of 3 ID strings for the alignment.Link instance. The string denotes the sub-identification of the aligner (or underlying resource) --- which are generally the version (or date).  
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info  
+   * @generated */
+  public void setVersion(String v) {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_version == null)
+      jcasType.jcas.throwFeatMissing("version", "eu.excitement.type.alignment.Link");
+    jcasType.ll_cas.ll_setStringValue(addr, ((Link_Type)jcasType).casFeatCode_version, v);}    
+   
+    
+  //*--------------*
+  //* Feature: info
+
+  /** getter for info - gets This is the thrid part of 3 ID strings for the alignment.Link instance. The string denotes the internal information about the added link; for example "synonym" (in WordNet based aligner), "stronger-than" (in VerbOcean based lexical aligner), or "local-entailment" (some aligner that aligned multiple structures). Thus, the value is defined by the aligner, and enable alginer to denote more than one relations that is identifiable by getID().
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info 
+   * @generated */
+  public String getInfo() {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_info == null)
+      jcasType.jcas.throwFeatMissing("info", "eu.excitement.type.alignment.Link");
+    return jcasType.ll_cas.ll_getStringValue(addr, ((Link_Type)jcasType).casFeatCode_info);}
+    
+  /** setter for info - sets This is the thrid part of 3 ID strings for the alignment.Link instance. The string denotes the internal information about the added link; for example "synonym" (in WordNet based aligner), "stronger-than" (in VerbOcean based lexical aligner), or "local-entailment" (some aligner that aligned multiple structures). Thus, the value is defined by the aligner, and enable alginer to denote more than one relations that is identifiable by getID().
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info  
+   * @generated */
+  public void setInfo(String v) {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_info == null)
+      jcasType.jcas.throwFeatMissing("info", "eu.excitement.type.alignment.Link");
+    jcasType.ll_cas.ll_setStringValue(addr, ((Link_Type)jcasType).casFeatCode_info, v);}    
+   
+    
+  //*--------------*
+  //* Feature: groupLabel
+
+  /** getter for groupLabel - gets TBDTBDTBDTBD
+
+TO BE DETERMINED. 
+
+We will adopt "common semantic groups", such as "LOCAL-ENTAILMENT" links, or "LOCAL-CONTRADICTION" links, and so on. This field is for those "labels". Such labels are provided as "Convenience" tools --- to help the consumer modules of alignment.Link can classify various Links without hard-coding aliner Id or link's getIDs. 
+
+Actual values for the labels will be updated. TBDTBDTBDTBD 
+   * @generated */
+  public StringList getGroupLabel() {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_groupLabel == null)
+      jcasType.jcas.throwFeatMissing("groupLabel", "eu.excitement.type.alignment.Link");
+    return (StringList)(jcasType.ll_cas.ll_getFSForRef(jcasType.ll_cas.ll_getRefValue(addr, ((Link_Type)jcasType).casFeatCode_groupLabel)));}
+    
+  /** setter for groupLabel - sets TBDTBDTBDTBD
+
+TO BE DETERMINED. 
+
+We will adopt "common semantic groups", such as "LOCAL-ENTAILMENT" links, or "LOCAL-CONTRADICTION" links, and so on. This field is for those "labels". Such labels are provided as "Convenience" tools --- to help the consumer modules of alignment.Link can classify various Links without hard-coding aliner Id or link's getIDs. 
+
+Actual values for the labels will be updated. TBDTBDTBDTBD  
+   * @generated */
+  public void setGroupLabel(StringList v) {
+    if (Link_Type.featOkTst && ((Link_Type)jcasType).casFeat_groupLabel == null)
+      jcasType.jcas.throwFeatMissing("groupLabel", "eu.excitement.type.alignment.Link");
+    jcasType.ll_cas.ll_setRefValue(addr, ((Link_Type)jcasType).casFeatCode_groupLabel, jcasType.ll_cas.ll_getFSRef(v));}    
   }
 
     

--- a/common/src/main/java/eu/excitement/type/alignment/Link_Type.java
+++ b/common/src/main/java/eu/excitement/type/alignment/Link_Type.java
@@ -15,12 +15,15 @@ import org.apache.uima.jcas.tcas.Annotation_Type;
 
 /** - CAS type that links two Target. 
 - Multi-view type: a Link connects one target in T (TextView), the other target in H (HypothesisView). 
-- Three features: "from" (alignment.Target), "to" (alignment.Target), and "strength" (double). 
 
-The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to". 
+The semantic of a "Link" is: The texts (or structures) pointed by "TSideTarget" and "HSideTarget" have a relation of "type", with the direction of "direction",  on a strength of "strength". 
 
- We make no assumptions regarding what annotations are aligned by Link and Target types. One Target can be linked by an arbitrary number of Link, also a Target can group an arbitrary number of Annotations. Note that uima.tcas.Annotation is the super type of almost all CAS annotation data. Since a Target can group Annotation, it can group any type of annotations in CAS. 
- * Updated by JCasGen Thu Apr 24 15:21:08 CEST 2014
+We make no assumptions regarding what annotations are aligned by Link and Target types. One Target can be linked by an arbitrary number of Link, also a Target can group an arbitrary number of Annotations. Note that uima.tcas.Annotation is the super type of almost all CAS annotation data. Since a Target can group Annotation, it can group any type of annotations in CAS.
+
+Some notes on Link type usage. (Indexing and setting begin - end) 
+- A Link instance should be indexed on the Hypothesis View. So one iteration over the Hypothesis view can get all alignment links.
+- begin and end : both span value should hold the same value to that of HSide Target 
+ * Updated by JCasGen Tue May 06 15:54:34 CEST 2014
  * @generated */
 public class Link_Type extends Annotation_Type {
   /** @generated */
@@ -51,38 +54,38 @@ public class Link_Type extends Annotation_Type {
   public final static boolean featOkTst = JCasRegistry.getFeatOkTst("eu.excitement.type.alignment.Link");
  
   /** @generated */
-  final Feature casFeat_from;
+  final Feature casFeat_TSideTarget;
   /** @generated */
-  final int     casFeatCode_from;
+  final int     casFeatCode_TSideTarget;
   /** @generated */ 
-  public int getFrom(int addr) {
-        if (featOkTst && casFeat_from == null)
-      jcas.throwFeatMissing("from", "eu.excitement.type.alignment.Link");
-    return ll_cas.ll_getRefValue(addr, casFeatCode_from);
+  public int getTSideTarget(int addr) {
+        if (featOkTst && casFeat_TSideTarget == null)
+      jcas.throwFeatMissing("TSideTarget", "eu.excitement.type.alignment.Link");
+    return ll_cas.ll_getRefValue(addr, casFeatCode_TSideTarget);
   }
   /** @generated */    
-  public void setFrom(int addr, int v) {
-        if (featOkTst && casFeat_from == null)
-      jcas.throwFeatMissing("from", "eu.excitement.type.alignment.Link");
-    ll_cas.ll_setRefValue(addr, casFeatCode_from, v);}
+  public void setTSideTarget(int addr, int v) {
+        if (featOkTst && casFeat_TSideTarget == null)
+      jcas.throwFeatMissing("TSideTarget", "eu.excitement.type.alignment.Link");
+    ll_cas.ll_setRefValue(addr, casFeatCode_TSideTarget, v);}
     
   
  
   /** @generated */
-  final Feature casFeat_to;
+  final Feature casFeat_HSideTarget;
   /** @generated */
-  final int     casFeatCode_to;
+  final int     casFeatCode_HSideTarget;
   /** @generated */ 
-  public int getTo(int addr) {
-        if (featOkTst && casFeat_to == null)
-      jcas.throwFeatMissing("to", "eu.excitement.type.alignment.Link");
-    return ll_cas.ll_getRefValue(addr, casFeatCode_to);
+  public int getHSideTarget(int addr) {
+        if (featOkTst && casFeat_HSideTarget == null)
+      jcas.throwFeatMissing("HSideTarget", "eu.excitement.type.alignment.Link");
+    return ll_cas.ll_getRefValue(addr, casFeatCode_HSideTarget);
   }
   /** @generated */    
-  public void setTo(int addr, int v) {
-        if (featOkTst && casFeat_to == null)
-      jcas.throwFeatMissing("to", "eu.excitement.type.alignment.Link");
-    ll_cas.ll_setRefValue(addr, casFeatCode_to, v);}
+  public void setHSideTarget(int addr, int v) {
+        if (featOkTst && casFeat_HSideTarget == null)
+      jcas.throwFeatMissing("HSideTarget", "eu.excitement.type.alignment.Link");
+    ll_cas.ll_setRefValue(addr, casFeatCode_HSideTarget, v);}
     
   
  
@@ -103,6 +106,96 @@ public class Link_Type extends Annotation_Type {
     ll_cas.ll_setDoubleValue(addr, casFeatCode_strength, v);}
     
   
+ 
+  /** @generated */
+  final Feature casFeat_direction;
+  /** @generated */
+  final int     casFeatCode_direction;
+  /** @generated */ 
+  public String getDirection(int addr) {
+        if (featOkTst && casFeat_direction == null)
+      jcas.throwFeatMissing("direction", "eu.excitement.type.alignment.Link");
+    return ll_cas.ll_getStringValue(addr, casFeatCode_direction);
+  }
+  /** @generated */    
+  public void setDirection(int addr, String v) {
+        if (featOkTst && casFeat_direction == null)
+      jcas.throwFeatMissing("direction", "eu.excitement.type.alignment.Link");
+    ll_cas.ll_setStringValue(addr, casFeatCode_direction, v);}
+    
+  
+ 
+  /** @generated */
+  final Feature casFeat_alignerID;
+  /** @generated */
+  final int     casFeatCode_alignerID;
+  /** @generated */ 
+  public String getAlignerID(int addr) {
+        if (featOkTst && casFeat_alignerID == null)
+      jcas.throwFeatMissing("alignerID", "eu.excitement.type.alignment.Link");
+    return ll_cas.ll_getStringValue(addr, casFeatCode_alignerID);
+  }
+  /** @generated */    
+  public void setAlignerID(int addr, String v) {
+        if (featOkTst && casFeat_alignerID == null)
+      jcas.throwFeatMissing("alignerID", "eu.excitement.type.alignment.Link");
+    ll_cas.ll_setStringValue(addr, casFeatCode_alignerID, v);}
+    
+  
+ 
+  /** @generated */
+  final Feature casFeat_version;
+  /** @generated */
+  final int     casFeatCode_version;
+  /** @generated */ 
+  public String getVersion(int addr) {
+        if (featOkTst && casFeat_version == null)
+      jcas.throwFeatMissing("version", "eu.excitement.type.alignment.Link");
+    return ll_cas.ll_getStringValue(addr, casFeatCode_version);
+  }
+  /** @generated */    
+  public void setVersion(int addr, String v) {
+        if (featOkTst && casFeat_version == null)
+      jcas.throwFeatMissing("version", "eu.excitement.type.alignment.Link");
+    ll_cas.ll_setStringValue(addr, casFeatCode_version, v);}
+    
+  
+ 
+  /** @generated */
+  final Feature casFeat_info;
+  /** @generated */
+  final int     casFeatCode_info;
+  /** @generated */ 
+  public String getInfo(int addr) {
+        if (featOkTst && casFeat_info == null)
+      jcas.throwFeatMissing("info", "eu.excitement.type.alignment.Link");
+    return ll_cas.ll_getStringValue(addr, casFeatCode_info);
+  }
+  /** @generated */    
+  public void setInfo(int addr, String v) {
+        if (featOkTst && casFeat_info == null)
+      jcas.throwFeatMissing("info", "eu.excitement.type.alignment.Link");
+    ll_cas.ll_setStringValue(addr, casFeatCode_info, v);}
+    
+  
+ 
+  /** @generated */
+  final Feature casFeat_groupLabel;
+  /** @generated */
+  final int     casFeatCode_groupLabel;
+  /** @generated */ 
+  public int getGroupLabel(int addr) {
+        if (featOkTst && casFeat_groupLabel == null)
+      jcas.throwFeatMissing("groupLabel", "eu.excitement.type.alignment.Link");
+    return ll_cas.ll_getRefValue(addr, casFeatCode_groupLabel);
+  }
+  /** @generated */    
+  public void setGroupLabel(int addr, int v) {
+        if (featOkTst && casFeat_groupLabel == null)
+      jcas.throwFeatMissing("groupLabel", "eu.excitement.type.alignment.Link");
+    ll_cas.ll_setRefValue(addr, casFeatCode_groupLabel, v);}
+    
+  
 
 
 
@@ -113,16 +206,36 @@ public class Link_Type extends Annotation_Type {
     casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl)this.casType, getFSGenerator());
 
  
-    casFeat_from = jcas.getRequiredFeatureDE(casType, "from", "eu.excitement.type.alignment.Target", featOkTst);
-    casFeatCode_from  = (null == casFeat_from) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_from).getCode();
+    casFeat_TSideTarget = jcas.getRequiredFeatureDE(casType, "TSideTarget", "eu.excitement.type.alignment.Target", featOkTst);
+    casFeatCode_TSideTarget  = (null == casFeat_TSideTarget) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_TSideTarget).getCode();
 
  
-    casFeat_to = jcas.getRequiredFeatureDE(casType, "to", "eu.excitement.type.alignment.Target", featOkTst);
-    casFeatCode_to  = (null == casFeat_to) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_to).getCode();
+    casFeat_HSideTarget = jcas.getRequiredFeatureDE(casType, "HSideTarget", "eu.excitement.type.alignment.Target", featOkTst);
+    casFeatCode_HSideTarget  = (null == casFeat_HSideTarget) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_HSideTarget).getCode();
 
  
     casFeat_strength = jcas.getRequiredFeatureDE(casType, "strength", "uima.cas.Double", featOkTst);
     casFeatCode_strength  = (null == casFeat_strength) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_strength).getCode();
+
+ 
+    casFeat_direction = jcas.getRequiredFeatureDE(casType, "direction", "eu.excitement.type.alignment.Direction", featOkTst);
+    casFeatCode_direction  = (null == casFeat_direction) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_direction).getCode();
+
+ 
+    casFeat_alignerID = jcas.getRequiredFeatureDE(casType, "alignerID", "uima.cas.String", featOkTst);
+    casFeatCode_alignerID  = (null == casFeat_alignerID) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_alignerID).getCode();
+
+ 
+    casFeat_version = jcas.getRequiredFeatureDE(casType, "version", "uima.cas.String", featOkTst);
+    casFeatCode_version  = (null == casFeat_version) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_version).getCode();
+
+ 
+    casFeat_info = jcas.getRequiredFeatureDE(casType, "info", "uima.cas.String", featOkTst);
+    casFeatCode_info  = (null == casFeat_info) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_info).getCode();
+
+ 
+    casFeat_groupLabel = jcas.getRequiredFeatureDE(casType, "groupLabel", "uima.cas.StringList", featOkTst);
+    casFeatCode_groupLabel  = (null == casFeat_groupLabel) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_groupLabel).getCode();
 
   }
 }

--- a/common/src/main/java/eu/excitement/type/alignment/Target.java
+++ b/common/src/main/java/eu/excitement/type/alignment/Target.java
@@ -13,8 +13,8 @@ import org.apache.uima.jcas.tcas.Annotation;
 
 /** This is a CAS annotation type that can point one or more annotations (tokens, parse nodes, NER nodes, or any annotations) 
 It is a list that groups annotations in one View. The target type allows flexible alignment between any data, including structures made by multiple annotations. 
-Note on usage: begin holds the minimum begin value among annotations in targetAnnotations. Likewise, end should point the maximum end among annotations. 
- * Updated by JCasGen Thu Apr 24 15:21:08 CEST 2014
+Note on usage: begin holds the minimum begin value among annotations in targetAnnotations. Likewise, end should point the maximum end among annotations.
+ * Updated by JCasGen Tue May 06 15:54:34 CEST 2014
  * XML source: /home/tailblues/progs/Excitement-Open-Platform/common/src/main/resources/desc/type/AlignmentTypes.xml
  * @generated */
 public class Target extends Annotation {

--- a/common/src/main/java/eu/excitement/type/alignment/Target_Type.java
+++ b/common/src/main/java/eu/excitement/type/alignment/Target_Type.java
@@ -15,8 +15,8 @@ import org.apache.uima.jcas.tcas.Annotation_Type;
 
 /** This is a CAS annotation type that can point one or more annotations (tokens, parse nodes, NER nodes, or any annotations) 
 It is a list that groups annotations in one View. The target type allows flexible alignment between any data, including structures made by multiple annotations. 
-Note on usage: begin holds the minimum begin value among annotations in targetAnnotations. Likewise, end should point the maximum end among annotations. 
- * Updated by JCasGen Thu Apr 24 15:21:08 CEST 2014
+Note on usage: begin holds the minimum begin value among annotations in targetAnnotations. Likewise, end should point the maximum end among annotations.
+ * Updated by JCasGen Tue May 06 15:54:34 CEST 2014
  * @generated */
 public class Target_Type extends Annotation_Type {
   /** @generated */
@@ -69,7 +69,7 @@ public class Target_Type extends Annotation_Type {
     if (lowLevelTypeChecks)
       return ll_cas.ll_getRefArrayValue(ll_cas.ll_getRefValue(addr, casFeatCode_targetAnnotations), i, true);
     jcas.checkArrayBounds(ll_cas.ll_getRefValue(addr, casFeatCode_targetAnnotations), i);
-	return ll_cas.ll_getRefArrayValue(ll_cas.ll_getRefValue(addr, casFeatCode_targetAnnotations), i);
+  return ll_cas.ll_getRefArrayValue(ll_cas.ll_getRefValue(addr, casFeatCode_targetAnnotations), i);
   }
    
   /** @generated */ 

--- a/common/src/main/java/eu/excitementproject/eop/common/component/alignment/AlignmentComponent.java
+++ b/common/src/main/java/eu/excitementproject/eop/common/component/alignment/AlignmentComponent.java
@@ -13,7 +13,7 @@ package eu.excitementproject.eop.common.component.alignment;
  * 
  * @author Tae-Gil Noh
  */
-public interface AlignmentComponent extends AnnotatorComponent {
+public interface AlignmentComponent extends PairAnnotatorComponent {
 	
 	// the interface adds no new methods
 	

--- a/common/src/main/java/eu/excitementproject/eop/common/component/alignment/PairAnnotatorComponent.java
+++ b/common/src/main/java/eu/excitementproject/eop/common/component/alignment/PairAnnotatorComponent.java
@@ -38,7 +38,7 @@ import eu.excitementproject.eop.common.component.Component;
  * @author Tae-Gil Noh
  */
 
-public interface AnnotatorComponent extends Component {
+public interface PairAnnotatorComponent extends Component {
 	
 	/**
 	 * The method gets one JCas. Once the annotate process is done, 

--- a/common/src/main/resources/desc/type/AlignmentTypes.xml
+++ b/common/src/main/resources/desc/type/AlignmentTypes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
   <name>AlignmentTypes</name>
-  <description>All components that implement AlignmentComponent must annotate according to the specific CAS types that are designed for alignment annotations within EOP. This file defines the two types needed for alignment within EOP. </description>
+  <description>All components that implement AlignmentComponent must annotate according to the specific CAS types that are designed for alignment annotations within EOP. This file defines the two types needed for alignment within EOP.</description>
   <version>1.0</version>
   <vendor/>
   <types>
@@ -8,12 +8,12 @@
       <name>eu.excitement.type.alignment.Target</name>
       <description>This is a CAS annotation type that can point one or more annotations (tokens, parse nodes, NER nodes, or any annotations) 
 It is a list that groups annotations in one View. The target type allows flexible alignment between any data, including structures made by multiple annotations. 
-Note on usage: begin holds the minimum begin value among annotations in targetAnnotations. Likewise, end should point the maximum end among annotations. </description>
+Note on usage: begin holds the minimum begin value among annotations in targetAnnotations. Likewise, end should point the maximum end among annotations.</description>
       <supertypeName>uima.tcas.Annotation</supertypeName>
       <features>
         <featureDescription>
           <name>targetAnnotations</name>
-          <description>This is a FSArray that can hold one or more annotations. A target should mark one or more annotations </description>
+          <description>This is a FSArray that can hold one or more annotations. A target should mark one or more annotations</description>
           <rangeTypeName>uima.cas.FSArray</rangeTypeName>
           <elementType>uima.tcas.Annotation</elementType>
         </featureDescription>
@@ -23,29 +23,95 @@ Note on usage: begin holds the minimum begin value among annotations in targetAn
       <name>eu.excitement.type.alignment.Link</name>
       <description>- CAS type that links two Target. 
 - Multi-view type: a Link connects one target in T (TextView), the other target in H (HypothesisView). 
-- Three features: "from" (alignment.Target), "to" (alignment.Target), and "strength" (double). 
 
-The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to". 
+The semantic of a "Link" is: The texts (or structures) pointed by "TSideTarget" and "HSideTarget" have a relation of "type", with the direction of "direction",  on a strength of "strength". 
 
- We make no assumptions regarding what annotations are aligned by Link and Target types. One Target can be linked by an arbitrary number of Link, also a Target can group an arbitrary number of Annotations. Note that uima.tcas.Annotation is the super type of almost all CAS annotation data. Since a Target can group Annotation, it can group any type of annotations in CAS. </description>
+We make no assumptions regarding what annotations are aligned by Link and Target types. One Target can be linked by an arbitrary number of Link, also a Target can group an arbitrary number of Annotations. Note that uima.tcas.Annotation is the super type of almost all CAS annotation data. Since a Target can group Annotation, it can group any type of annotations in CAS.
+
+Some notes on Link type usage. (Indexing and setting begin - end) 
+- A Link instance should be indexed on the Hypothesis View. So one iteration over the Hypothesis view can get all alignment links.
+- begin and end : both span value should hold the same value to that of HSide Target </description>
       <supertypeName>uima.tcas.Annotation</supertypeName>
       <features>
         <featureDescription>
-          <name>from</name>
-          <description>This feature points one Target. Mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to". </description>
+          <name>TSideTarget</name>
+          <description>This feature points one Target in TEXTVIEW side. A mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) targets have the relation of "type" between them, with the direction of "direction".</description>
           <rangeTypeName>eu.excitement.type.alignment.Target</rangeTypeName>
         </featureDescription>
         <featureDescription>
-          <name>to</name>
-          <description>This feature points one Target. Mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) pointed by "from" has a relation of "type" to the text (or structure) pointed in "to". </description>
+          <name>HSideTarget</name>
+          <description>This feature points one Target in HYPOTHESISVIEW side. A mandatory value, and should not be null. The semantic of a "Link" is: The text (or structure) targets have the relation of "type" between them, with the direction of "direction".</description>
           <rangeTypeName>eu.excitement.type.alignment.Target</rangeTypeName>
         </featureDescription>
         <featureDescription>
           <name>strength</name>
-          <description>This feature keeps one double (numerical) value. Mandatory value, and should not be null. The value indicates the strength of the relation. </description>
+          <description>This feature keeps one double (numerical) value. Mandatory value, and should not be null. The value indicates the strength of the relation.</description>
           <rangeTypeName>uima.cas.Double</rangeTypeName>
         </featureDescription>
+        <featureDescription>
+          <name>direction</name>
+          <description>This value denotes the "direction" of the alignment.Link. Enum-like value that holds one of "TtoH", "HtoT", or "Symmetric". 
+</description>
+          <rangeTypeName>eu.excitement.type.alignment.Direction</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>alignerID</name>
+          <description>This is the first part of 3 ID strings for the alignment.Link instance. The string denotes the idetification of the aligner (or underlying resource). 
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info </description>
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>version</name>
+          <description>This is the second part of 3 ID strings for the alignment.Link instance. The string denotes the sub-identification of the aligner (or underlying resource) --- which are generally the version (or date).  
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info </description>
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>info</name>
+          <description>This is the thrid part of 3 ID strings for the alignment.Link instance. The string denotes the internal information about the added link; for example "synonym" (in WordNet based aligner), "stronger-than" (in VerbOcean based lexical aligner), or "local-entailment" (some aligner that aligned multiple structures). Thus, the value is defined by the aligner, and enable alginer to denote more than one relations that is identifiable by getID().
+
+It is the convention to use getID() method of alignment.Link to get the concatenated, unique string for the instance. getID() returns such a string by concatenating 3 ID strings: 
+alignerID + version + info </description>
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>groupLabel</name>
+          <description>TBDTBDTBDTBD
+
+TO BE DETERMINED. 
+
+We will adopt "common semantic groups", such as "LOCAL-ENTAILMENT" links, or "LOCAL-CONTRADICTION" links, and so on. This field is for those "labels". Such labels are provided as "Convenience" tools --- to help the consumer modules of alignment.Link can classify various Links without hard-coding aliner Id or link's getIDs. 
+
+Actual values for the labels will be updated. TBDTBDTBDTBD </description>
+          <rangeTypeName>uima.cas.StringList</rangeTypeName>
+        </featureDescription>
       </features>
+    </typeDescription>
+    <typeDescription>
+      <name>eu.excitement.type.alignment.Direction</name>
+      <description>A string sub-type for direciton marking. This type is a enum-like value that holds all possible directional marker for alignment.Link. This value is only to be used within an alignment.Link instance. 
+
+Allowed values are: "TtoH", "HtoT", "Symmetric"</description>
+      <supertypeName>uima.cas.String</supertypeName>
+      <allowedValues>
+        <value>
+          <string>TtoH</string>
+          <description>The relation is from TSideTarget to HSideTarget. </description>
+        </value>
+        <value>
+          <string>HtoT</string>
+          <description>The relation is from HSideTarget to TSideTarget
+</description>
+        </value>
+        <value>
+          <string>Symmetric</string>
+          <description>The relation is a symmetric one. (Both TSideTarget to HSideTarget and HSideTarget to TSideTarget.) </description>
+        </value>
+      </allowedValues>
     </typeDescription>
   </types>
 </typeSystemDescription>


### PR DESCRIPTION
This pull request has two changes 
- update of alignment.Link type: it is now updated in accordance to V3 proposal; that is described in the Google Slides shared in the mailing list. 
- (minor) renamed AnnotatorComponent to PairAnnotatorComponent --- to distinguish annotator from LAP layer annotators. 
