### PR TITLE
patch for MaltParser pipeline issue

### DIFF
--- a/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MaltParserDE.java
+++ b/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MaltParserDE.java
@@ -1,6 +1,15 @@
 package eu.excitementproject.eop.lap.dkpro;
 
+import static org.uimafit.factory.AnalysisEngineFactory.createPrimitiveDescription;
+
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.resource.ResourceInitializationException;
+
+import de.tudarmstadt.ukp.dkpro.core.maltparser.MaltParser;
+import de.tudarmstadt.ukp.dkpro.core.opennlp.OpenNlpSegmenter;
+import de.tudarmstadt.ukp.dkpro.core.treetagger.TreeTaggerPosLemmaTT4J;
 import eu.excitementproject.eop.lap.LAPException;
+import eu.excitementproject.eop.lap.implbase.LAP_ImplBaseAE;
 
 /**
  * 
@@ -8,13 +17,13 @@ import eu.excitementproject.eop.lap.LAPException;
  * class extends <code>MaltParserEN</code> and changes the
  * <code>languageIdentifier</code>.
  * 
- * TODO: train more models for parsing German; for the moment, only the default model is available.
+ * For German, we have only the default model. (Model variant, "default" only)
  * 
- * @author Rui
+ * @author Tae-Gil Noh 
  * 
  */
 
-public class MaltParserDE extends MaltParserEN {
+public class MaltParserDE extends LAP_ImplBaseAE {
 
 	/**
 	 * the default, simple constructor. Will generate default pipeline with
@@ -23,24 +32,32 @@ public class MaltParserDE extends MaltParserEN {
 	 * @throws LAPException
 	 */
 	public MaltParserDE() throws LAPException {
-		super();
-		languageIdentifier = "DE";
+		this(null); // default model 
 	}
 
 	/**
 	 * constructor with parameter for the classifier.
 	 * 
-	 * @param listAEDescriptorsArgs
-	 *            the parameter for the underlying AEs. This pipeline only has
-	 *            one argument PARSER_MODEL_VARIANT. Null means all default
-	 *            variable (default model) Note that passing unknown model will
-	 *            raise EXCEPTION from the UIMA AE. Note that there is no other
-	 *            models than the default one available for German for the
-	 *            moment!
+	 * @param modelVariant "variant string" for the model. This component provides only one variant called "default".
 	 * @throws LAPException
 	 */
 	public MaltParserDE(String modelVariant) throws LAPException {
-		super(modelVariant);
+		AnalysisEngineDescription[] descArr = new AnalysisEngineDescription[3];
+		
+		try {
+			descArr[0] = createPrimitiveDescription(OpenNlpSegmenter.class);
+			descArr[1] = createPrimitiveDescription(TreeTaggerPosLemmaTT4J.class);
+			descArr[2] = createPrimitiveDescription(MaltParser.class,
+					MaltParser.PARAM_VARIANT, modelVariant,
+					MaltParser.PARAM_PRINT_TAGSET, true);
+		} catch (ResourceInitializationException e) {
+			throw new LAPException("Unable to create AE descriptions", e);
+		}
+		
+		// b) call initializeViews() 
+		initializeViews(descArr); 
+		
+		// c) set lang ID 
 		languageIdentifier = "DE";
 	}
 
@@ -62,4 +79,5 @@ public class MaltParserDE extends MaltParserEN {
 //		super(views, listAEDescriptorsArgs);
 //		languageIdentifier = "DE";
 //	}
+	
 }

--- a/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MaltParserEN.java
+++ b/lap/src/main/java/eu/excitementproject/eop/lap/dkpro/MaltParserEN.java
@@ -9,6 +9,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 
 import de.tudarmstadt.ukp.dkpro.core.maltparser.MaltParser;
+import de.tudarmstadt.ukp.dkpro.core.opennlp.OpenNlpPosTagger;
 import de.tudarmstadt.ukp.dkpro.core.opennlp.OpenNlpSegmenter;
 import de.tudarmstadt.ukp.dkpro.core.treetagger.TreeTaggerPosLemmaTT4J;
 import eu.excitementproject.eop.lap.LAPException;
@@ -49,17 +50,35 @@ public class MaltParserEN extends LAP_ImplBaseAE {
 	public MaltParserEN(String modelVariant) throws LAPException {
 		
 		// a) prepare AEs 
-		AnalysisEngineDescription[] descArr = new AnalysisEngineDescription[3];
+//		AnalysisEngineDescription[] descArr = new AnalysisEngineDescription[3];
+//		
+//		try {
+//			descArr[0] = createPrimitiveDescription(OpenNlpSegmenter.class);
+//			descArr[1] = createPrimitiveDescription(TreeTaggerPosLemmaTT4J.class);
+//			descArr[2] = createPrimitiveDescription(MaltParser.class,
+//					MaltParser.PARAM_VARIANT, modelVariant,
+//					MaltParser.PARAM_PRINT_TAGSET, true);
+//		} catch (ResourceInitializationException e) {
+//			throw new LAPException("Unable to create AE descriptions", e);
+//		}
+
+		// Gil: Temporary code until we can use PosMapper (of later DKPros (> 1.5))
+		// TreeTagger first adds POS and Lemma, then POS overridden by OpenNLP. 
+		// Note that, TreeTaggers POS annotations are still there in AnnotationIndex, 
+		// but lost connection from Token annotations. Thus, parser only see OpenNLP POS. 
+		AnalysisEngineDescription[] descArr = new AnalysisEngineDescription[4];
 		
 		try {
 			descArr[0] = createPrimitiveDescription(OpenNlpSegmenter.class);
 			descArr[1] = createPrimitiveDescription(TreeTaggerPosLemmaTT4J.class);
-			descArr[2] = createPrimitiveDescription(MaltParser.class,
+			descArr[2] = createPrimitiveDescription(OpenNlpPosTagger.class);
+			descArr[3] = createPrimitiveDescription(MaltParser.class,
 					MaltParser.PARAM_VARIANT, modelVariant,
 					MaltParser.PARAM_PRINT_TAGSET, true);
 		} catch (ResourceInitializationException e) {
 			throw new LAPException("Unable to create AE descriptions", e);
 		}
+
 		
 		// b) call initializeViews() 
 		initializeViews(descArr); 

--- a/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/MaltParserDeTest.java
+++ b/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/MaltParserDeTest.java
@@ -70,9 +70,11 @@ public class MaltParserDeTest {
 		try {
 			JCas textCas = aJCas.getView("TextView");
 			JCas hypoCas = aJCas.getView("HypothesisView");
+		System.out.println("---dependency in textview---"); 	
 		for (Dependency dep : JCasUtil.select(textCas, Dependency.class)) {
 			System.out.println(dep.getGovernor().getCoveredText() + " -" + dep.getDependencyType() + "-> " + dep.getDependent().getCoveredText());
 		}
+		System.out.println("---dependency in hypoview---"); 
 		for (Dependency dep : JCasUtil.select(hypoCas, Dependency.class)) {
 			System.out.println(dep.getGovernor().getCoveredText() + " -" + dep.getDependencyType() + "-> " + dep.getDependent().getCoveredText());
 		}

--- a/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/MaltParserEnTest.java
+++ b/lap/src/test/java/eu/excitementproject/eop/lap/dkpro/MaltParserEnTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 //import java.util.HashMap;
 
+
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
@@ -40,9 +41,11 @@ public class MaltParserEnTest {
 			lap = new MaltParserEN(); // same as default, which is linear
 			
 			// one of the LAPAccess interface: that generates single TH CAS. 
-			aJCas = lap.generateSingleTHPairCAS("Bush used his weekly radio address to try to build support for his plan to allow workers to divert part of their Social Security payroll taxes into private investment accounts", "Mr. Bush is proposing that workers be allowed to divert their payroll taxes into private accounts."); 
+			//aJCas = lap.generateSingleTHPairCAS("Bush used his weekly radio address to try to build support for his plan to allow workers to divert part of their Social Security payroll taxes into private investment accounts", "Mr. Bush is proposing that workers be allowed to divert their payroll taxes into private accounts."); 
+			aJCas = lap.generateSingleTHPairCAS("I live in a house.", "The dog is also living in a house." ); 
 			
 			PlatformCASProber.probeCas(aJCas, System.out); 
+			//PlatformCASProber.probeCasAndPrintContent(aJCas, System.out);
 			
 			// poly model test 
 			// This will load poly model, and trace output will show "poly" too. 
@@ -69,9 +72,11 @@ public class MaltParserEnTest {
 		try {
 			JCas textCas = aJCas.getView("TextView");
 			JCas hypoCas = aJCas.getView("HypothesisView");
+		System.out.println("---dependency in textview---"); 
 		for (Dependency dep : JCasUtil.select(textCas, Dependency.class)) {
 			System.out.println(dep.getGovernor().getCoveredText() + " -" + dep.getDependencyType() + "-> " + dep.getDependent().getCoveredText());
 		}
+		System.out.println("---dependency in hypoview---"); 
 		for (Dependency dep : JCasUtil.select(hypoCas, Dependency.class)) {
 			System.out.println(dep.getGovernor().getCoveredText() + " -" + dep.getDependencyType() + "-> " + dep.getDependent().getCoveredText());
 		}


### PR DESCRIPTION
A patch for #431, Malt Parser output broken for English. 

Temporary patch for MaltParser English pipeline. --- Previously, MaltParser expected (pure) PennTree POS tags, while TreeTagger provided additional POS tags. 

This patch resolves this by using POS tags provided by OpenNLPPosTagger. (lemma is still using TreeTagger). --- this is only a temporary solution, since we would prefer TreeTagger POS tagger. Final patch using PosMapper (of DKPro 1.5 and 1.6) will be added after the update of DKPro (#436). 

Anyhow, now Malt Parser works correctly on English (while a bit not very optimal). 
