### PR TITLE
Bugs fixed in MetaEDA "SimpleMetaEDAConfidenceFeatures"

### DIFF
--- a/core/src/main/java/eu/excitementproject/eop/core/metaeda/SimpleMetaEDAConfidenceFeatures.java
+++ b/core/src/main/java/eu/excitementproject/eop/core/metaeda/SimpleMetaEDAConfidenceFeatures.java
@@ -107,6 +107,14 @@ public class SimpleMetaEDAConfidenceFeatures implements EDABasic<TEDecision>{
 	}
 	
 	/**
+	 * returns the classifier
+	 * @return
+	 */
+	public Logistic getClassifier(){
+		return this.classifier;
+	}
+	
+	/**
 	 * Initializes a SimpleMetaEDAConfidenceFeatures instance with a configuration file, 
 	 * where training and decision mode, overwrite mode,
 	 * path to model file, training data and test data directory are defined

--- a/core/src/main/java/eu/excitementproject/eop/core/metaeda/SimpleMetaEDAConfidenceFeaturesUsageExample.java
+++ b/core/src/main/java/eu/excitementproject/eop/core/metaeda/SimpleMetaEDAConfidenceFeaturesUsageExample.java
@@ -848,6 +848,10 @@ public class SimpleMetaEDAConfidenceFeaturesUsageExample {
 	 */
 	private void printDecisionTable(SimpleMetaEDAConfidenceFeatures meda) {
 		//print detailed classification overview table for test data
+		if (meda.isConfidenceAsFeature()){
+			System.out.println(Arrays.deepToString(meda.getClassifier().coefficients()));
+		}
+		
 		HashMap<Integer, float[]> results = meda.getResults();
 		StringBuffer sb = new StringBuffer();
 		sb.append(String.format("%30s", "PairID")+String.format("%30s", "GoldLabel"));


### PR DESCRIPTION
SimpleMetaEDAConfidenceFeatures:
- in case of a tie in voting mode, return NonEntailment
- logger changed to log4j 
- starttraining() is callable without config file but with parameters
- changed classifier from naive bayes to logistic 
  SimpleMetaEDAConfidenceFeaturesUsageExample:
- new feature: collect classification test results and print them in a table
